### PR TITLE
Themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2509,6 +2509,11 @@
         "vue-functional-data-merge": "^3.1.0"
       }
     },
+    "bootswatch": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-4.5.0.tgz",
+      "integrity": "sha512-kAfYTTWIsgUOA5nybJNM4yvOpwxm37eIb1DFZlD5jLgPttK+bLJTt9UpKWAoMQZRBQbWfC1O1w1P5PGU7lz83Q=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios": "^0.19.2",
     "bootstrap": "^4.5.0",
     "bootstrap-vue": "^2.14.0",
+    "bootswatch": "^4.5.0",
     "core-js": "^3.6.4",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,9 @@ import Body from '@/components/layout/Body.vue';
 
 export default {
   components: { Container, Header, Body },
+  mounted() {
+    this.$store.dispatch('theme/initTheme');
+  },
 };
 </script>
 

--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -16,6 +16,10 @@
 
         <!-- Right aligned nav items -->
         <b-navbar-nav class="ml-auto">
+          <li class="nav-item">
+            <b-checkbox ize="lg" switch @change="changeTheme" />
+          </li>
+
           <li class="nav-item" v-if="loggedIn">
             <b-nav-item-dropdown right>
               <template v-slot:button-content>
@@ -47,6 +51,7 @@ export default {
   },
   methods: {
     ...mapActions('user', ['logout']),
+    ...mapActions('theme', ['changeTheme']),
   },
 };
 </script>

--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -17,7 +17,9 @@
         <!-- Right aligned nav items -->
         <b-navbar-nav class="ml-auto">
           <li class="nav-item">
-            <b-checkbox ize="lg" switch @change="changeTheme" />
+            <b-checkbox v-model="DarkTheme" size="lg" checked switch @change="changeTheme"
+              >Dark</b-checkbox
+            >
           </li>
 
           <li class="nav-item" v-if="loggedIn">
@@ -45,6 +47,11 @@ import Login from '@/views/Login.vue';
 
 export default {
   name: 'NavBar',
+  data() {
+    return {
+      DarkTheme: true,
+    };
+  },
   components: { Login },
   computed: {
     ...mapState('user', ['loggedIn']),

--- a/src/plugins/bootstrap-vue.js
+++ b/src/plugins/bootstrap-vue.js
@@ -5,7 +5,7 @@ import BootstrapVue from 'bootstrap-vue';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
 // Changing the below sequence will also change functionality from store/theme.js
-import 'bootswatch/dist/superhero/bootstrap.min.css';
-import 'bootswatch/dist/sketchy/bootstrap.min.css';
+import 'bootswatch/dist/darkly/bootstrap.min.css';
+import 'bootswatch/dist/flatly/bootstrap.min.css';
 
 Vue.use(BootstrapVue);

--- a/src/plugins/bootstrap-vue.js
+++ b/src/plugins/bootstrap-vue.js
@@ -4,5 +4,8 @@ import BootstrapVue from 'bootstrap-vue';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
+// Changing the below sequence will also change functionality from store/theme.js
+import 'bootswatch/dist/superhero/bootstrap.min.css';
+import 'bootswatch/dist/sketchy/bootstrap.min.css';
 
 Vue.use(BootstrapVue);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import Vuex from 'vuex';
 import ftbotModule from './modules/ftbot';
 import userModule from './modules/user';
 import alertsModule from './modules/alerts';
+import themeModule from './modules/theme';
 
 Vue.use(Vuex);
 
@@ -13,6 +14,7 @@ export default new Vuex.Store({
     ftbot: ftbotModule,
     user: userModule,
     alerts: alertsModule,
+    theme: themeModule,
   },
   mutations: {
     setPing(state, ping) {

--- a/src/store/modules/theme.js
+++ b/src/store/modules/theme.js
@@ -1,0 +1,32 @@
+export default {
+  namespaced: true,
+  state: {
+    theme: 'dark',
+  },
+  mutations: {
+    changeTheme(state, theme) {
+      console.log(`Changing theme to ${theme}`);
+      state.theme = theme;
+    },
+  },
+  actions: {
+    changeTheme({ commit }) {
+      const dark = document.getElementById('darkthemecss');
+      dark.disabled = !dark.disabled;
+      const bright = document.getElementById('brightthemecss');
+      bright.disabled = !bright.disabled;
+      const theme = dark.disabled ? 'bright' : 'dark';
+      commit('changeTheme', theme);
+    },
+    initTheme() {
+      // Get all styles - search bootswatch.
+      // Dark / bright are guessed based on import direction in bootstrap-vue.js
+      const styles = document.getElementsByTagName('style');
+      const bw = Array.from(styles).filter((w) => w.textContent.includes('bootswatch'));
+      bw[0].id = 'darkthemecss';
+      bw[1].id = 'brightthemecss';
+      // Default to dark theme
+      bw[1].disabled = true;
+    },
+  },
+};


### PR DESCRIPTION
Introduce Light / dark theme switcher based on https://bootswatch.com/.

The selection is currently superhero (for dark) - and Sketchy (for bright) - but neither of these are a must (we can also use more styles eventually).

The  idea of the style switcher is: 
* Load both styles in sequence
* Assign them id's
* disable the one that's not needed
* switch to the other theme.

Currently, there is no persistence implemented - so the "dark" switch will still change (it currently may show dark while it's really white ...)

However, it would be good to have a 2nd opinion on this (especially on the way to implement the switching).

