### PR TITLE
fix docker dev container node_modules binding

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,15 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+
+
+RUN yarn global add @vue/cli
+
+USER $USERNAME
+
 ENV HOME /home/$USERNAME
+
+RUN mkdir -p $HOME/frequi/node_modules
 
 WORKDIR $HOME/frequi
 
@@ -30,9 +38,6 @@ COPY ./package.json .
 
 # install dependencies
 RUN yarn install
-RUN yarn global add @vue/cli
-
-USER $USERNAME
 
 EXPOSE 8080
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     image: freqtradeorg/frequi:dev
     user: dev
     volumes:
-      - ../node_modules:/home/dev/frequi/node_modules
       - ../:/home/dev/frequi
+      - frequi-node-modules:/home/dev/frequi/node_modules
     command: /bin/sh -c "while sleep 1000; do :; done"
     networks:
       - frequi
@@ -18,3 +18,6 @@ services:
 
 networks:
   frequi:
+
+volumes:
+  frequi-node-modules:


### PR DESCRIPTION
When binding source directory it erase node_modules of the container. I have create a named volume   frequi-node-modules that is bind in a second time to ensure providing files.

What's new ?
- Fix the binding of node_modules to prevent to be empty
- Fix vue command not available