### PR TITLE
Fix trailing zeros in TradeDetail view

### DIFF
--- a/src/components/ftbot/TradeDetail.vue
+++ b/src/components/ftbot/TradeDetail.vue
@@ -6,10 +6,10 @@
         <ValuePair description="TradeId">{{ trade.trade_id }}</ValuePair>
         <ValuePair description="Pair">{{ trade.pair }}</ValuePair>
         <ValuePair description="Open date">{{ timestampms(trade.open_timestamp) }}</ValuePair>
-        <ValuePair description="Open Rate">{{ trade.open_rate }}</ValuePair>
-        <ValuePair v-if="!trade.is_open" description="Close Rate">{{ trade.close_rate }}</ValuePair>
-        <ValuePair description="Min Rate">{{ trade.min_rate }}</ValuePair>
-        <ValuePair description="Max Rate">{{ trade.max_rate }}</ValuePair>
+        <ValuePair description="Open Rate">{{ formatPrice(trade.open_rate) }}</ValuePair>
+        <ValuePair v-if="!trade.is_open" description="Close Rate">{{ formatPrice(trade.close_rate) }}</ValuePair>
+        <ValuePair description="Min Rate">{{ formatPrice(trade.min_rate) }}</ValuePair>
+        <ValuePair description="Max Rate">{{ formatPrice(trade.max_rate) }}</ValuePair>
         <ValuePair v-if="trade.close_timestamp" description="Close date">{{
           timestampms(trade.close_timestamp)
         }}</ValuePair>


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Some rates in the "Trade Detail" view were not using the formatPercent() helper and due to this, the view was trailing zeros.

## Quick changelog

- Use formatPercent() for all the rates in TradeDetail view

## What's new

* Before (don't pay attention to the "Min Rate" as it chanched while I was taking the screen shot)
<img width="228" alt="Screen Shot 2020-10-19 at 19 50 25" src="https://user-images.githubusercontent.com/22173704/96520264-1340f680-1245-11eb-819a-5ceb84fe450f.png">

* After
<img width="243" alt="Screen Shot 2020-10-19 at 19 36 06" src="https://user-images.githubusercontent.com/22173704/96520262-10de9c80-1245-11eb-9066-e80d1d595bb7.png">

