### PR TITLE
feat: add support for routes loaded from URL (custom nginx config)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY . /app
 RUN yarn build
 
 FROM nginx:alpine
-COPY  --from=ui-builder /app/dist /usr/share/nginx/html
+COPY  --from=ui-builder /app/dist /etc/nginx/html
+COPY  --from=ui-builder /app/nginx.conf /etc/nginx/nginx.conf
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["nginx"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,47 @@
+# run nginx in foreground
+daemon off;
+
+#user  nobody;
+worker_processes  1;
+
+#error_log  logs/error.log;
+error_log stderr notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    access_log /dev/stdout;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+            # redirect 404 to index
+            try_files $uri /index.html;
+        }
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   html;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add support for routes loaded from URL.
For instance, the /dashboard route, when typed and loaded in the bar adress, returns a 404.


## Quick changelog

- Add support for routes loaded from URL.
- Add custom nginx config.

## What's new

I added our custom Nginx config in the Dockerfile.

This config comes from the repo nginx:alpine, so it's the exact same config than before, but with this line added:
`try_files $uri /index.html;`

Which will redirect to index.html when no asset found.

Link to original nginx:alpine config: https://bitbucket.org/yobasystems/alpine-nginx/src/master/alpine-nginx-aarch64/files/nginx.conf
