### PR TITLE
multi-pane window to overflow after reaching the max height h-100 and adjust the chart labels

### DIFF
--- a/src/components/charts/CumProfitChart.vue
+++ b/src/components/charts/CumProfitChart.vue
@@ -92,7 +92,7 @@ export default class CumProfitChart extends Vue {
           },
           nameRotate: 90,
           nameLocation: 'middle',
-          nameGap: 30,
+          nameGap: 40,
         },
         {
           type: 'value',

--- a/src/components/charts/DailyChart.vue
+++ b/src/components/charts/DailyChart.vue
@@ -104,7 +104,7 @@ export default class DailyChart extends Vue {
           },
           nameRotate: 90,
           nameLocation: 'middle',
-          nameGap: 30,
+          nameGap: 50,
         },
         {
           type: 'value',

--- a/src/components/layout/DraggableContainer.vue
+++ b/src/components/layout/DraggableContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card h-100 w-100">
+  <div class="card h-100 w-100 overflow-auto">
     <div class="drag-header card-header">
       {{ header }}
     </div>


### PR DESCRIPTION
## Summary
Fixed the issue if the multi-pane list grows beyond the h-100 then overflow

closes #256 

## Quick changelog

- Added the overflow-auto at the card div which will ensure that card height would be limited to 100%


Result
![screencapture-expected](https://user-images.githubusercontent.com/1327311/107488172-f8164000-6bc1-11eb-97d7-7b9788b2cde2.png)

