### PR TITLE
make tooltip jump instead of follow

### DIFF
--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -169,10 +169,10 @@ export default class CandleChart extends Vue {
           },
         },
         // positioning copied from https://echarts.apache.org/en/option.html#tooltip.position
-        position: function (pos, params, dom, rect, size) {
+        position(pos, params, dom, rect, size) {
           // tooltip will be fixed on the right if mouse hovering on the left,
           // and on the left if hovering on the right.
-          var obj = {top: 60};
+          const obj = { top: 60 };
           obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 5;
           return obj;
         },

--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -168,6 +168,14 @@ export default class CandleChart extends Vue {
             opacity: 1,
           },
         },
+        // positioning copied from https://echarts.apache.org/en/option.html#tooltip.position
+        position: function (pos, params, dom, rect, size) {
+          // tooltip will be fixed on the right if mouse hovering on the left,
+          // and on the left if hovering on the right.
+          var obj = {top: 60};
+          obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 5;
+          return obj;
+        },
       },
       axisPointer: {
         link: [{ xAxisIndex: 'all' }],


### PR DESCRIPTION
Goes to left or right end of the chart when the crosshairs/mouse passes over it, instead of just following the crosshairs.
