### PR TITLE
Add buy tag to trade detail

### DIFF
--- a/src/components/ftbot/TradeDetail.vue
+++ b/src/components/ftbot/TradeDetail.vue
@@ -6,6 +6,7 @@
         <ValuePair description="TradeId">{{ trade.trade_id }}</ValuePair>
         <ValuePair description="Pair">{{ trade.pair }}</ValuePair>
         <ValuePair description="Open date">{{ timestampms(trade.open_timestamp) }}</ValuePair>
+        <ValuePair description="Buy tag">{{ trade.buy_tag }}</ValuePair>
         <ValuePair description="Open Rate">{{ formatPrice(trade.open_rate) }}</ValuePair>
         <ValuePair v-if="!trade.is_open && trade.close_rate" description="Close Rate">{{
           formatPrice(trade.close_rate)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Add buy tag to Trade Detail.

## Quick changelog

trade.buy_tag added to TradeDetail.vue

## What's new

The buy_tag of the trade will be displayed in the Trade Detail window in the left General column between Open date and Open rate.

![image](https://user-images.githubusercontent.com/15308516/130673484-57c9a71b-2415-4585-a0d4-386ce93a7b10.png)