### PR TITLE
Remove axisPointer.label for chart readability

### DIFF
--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -191,6 +191,9 @@ export default class CandleChart extends Vue {
           axisLine: { onZero: false },
           axisTick: { show: true },
           axisLabel: { show: true },
+          axisPointer: {
+            label: { show: false },
+          },
           position: 'top',
           splitLine: { show: false },
           splitNumber: 20,
@@ -205,6 +208,9 @@ export default class CandleChart extends Vue {
           axisLine: { onZero: false },
           axisTick: { show: false },
           axisLabel: { show: false },
+          axisPointer: {
+            label: { show: false },
+          },
           splitLine: { show: false },
           splitNumber: 20,
           min: 'dataMin',
@@ -449,6 +455,9 @@ export default class CandleChart extends Vue {
             axisLine: { onZero: false },
             axisTick: { show: false },
             axisLabel: { show: false },
+            axisPointer: {
+              label: { show: false },
+            },
             splitLine: { show: false },
             splitNumber: 20,
           });


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Set xAxis.axisPointer.label to false for main and subplots in CandleChart.vue


## What's new

Helps to improve readability on charts
here are some pictures :

with dateTime labels :
![wlabels](https://user-images.githubusercontent.com/1523359/133609797-2b2f7a37-17f6-4516-af12-374e6ea934d6.jpg)

without dateTime labels :
![wolabels](https://user-images.githubusercontent.com/1523359/133609840-f29caae8-82f8-4b73-a012-146d12156dc3.jpg)

<!-- Please include visuals if this Pull Request changes how things look-->
