### PR TITLE
feat: heikin ashi format dataset

### DIFF
--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -9,7 +9,7 @@ import { Component, Vue, Prop, Watch } from 'vue-property-decorator';
 import { Trade, PairHistory, PlotConfig } from '@/types';
 import randomColor from '@/shared/randomColor';
 import { roundTimeframe } from '@/shared/timemath';
-import { heikinAshiDataset } from '@/shared/formatters';
+import heikinashi from '@/shared/heikinashi';
 import ECharts from 'vue-echarts';
 
 import { use } from 'echarts/core';
@@ -353,7 +353,7 @@ export default class CandleChart extends Vue {
     const options: EChartsOption = {
       dataset: {
         source: this.heikinAshi
-          ? heikinAshiDataset(this.datasetColumns, this.dataset.data)
+          ? heikinashi(this.datasetColumns, this.dataset.data)
           : this.dataset.data,
       },
       grid: [

--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -9,6 +9,7 @@ import { Component, Vue, Prop, Watch } from 'vue-property-decorator';
 import { Trade, PairHistory, PlotConfig } from '@/types';
 import randomColor from '@/shared/randomColor';
 import { roundTimeframe } from '@/shared/timemath';
+import { heikinAshiDataset } from '@/shared/formatters';
 import ECharts from 'vue-echarts';
 
 import { use } from 'echarts/core';
@@ -82,6 +83,8 @@ export default class CandleChart extends Vue {
 
   @Prop({ required: true }) readonly dataset!: PairHistory;
 
+  @Prop({ type: Boolean, default: false }) heikinAshi!: boolean;
+
   @Prop({ default: true }) readonly useUTC!: boolean;
 
   @Prop({ required: true }) plotConfig!: PlotConfig;
@@ -102,6 +105,11 @@ export default class CandleChart extends Vue {
   @Watch('plotConfig')
   plotConfigChanged() {
     this.initializeChartOptions();
+  }
+
+  @Watch('heikinAshi')
+  heikinAshiChanged() {
+    this.updateChart();
   }
 
   get strategy() {
@@ -344,7 +352,9 @@ export default class CandleChart extends Vue {
 
     const options: EChartsOption = {
       dataset: {
-        source: this.dataset.data,
+        source: this.heikinAshi
+          ? heikinAshiDataset(this.datasetColumns, this.dataset.data)
+          : this.dataset.data,
       },
       grid: [
         {

--- a/src/components/charts/CandleChartContainer.vue
+++ b/src/components/charts/CandleChartContainer.vue
@@ -40,18 +40,24 @@
             >Short exits: {{ dataset.exit_short_signals }}</small
           >
         </div>
-        <div class="ml-auto mr-2">
-          <b-select
-            v-model="plotConfigName"
-            :options="availablePlotConfigNames"
-            size="sm"
-            @change="plotConfigChanged"
-          >
-          </b-select>
-        </div>
+        <div class="ml-auto d-flex align-items-center">
+          <b-form-checkbox v-model="heikinAshi">Heikin Ashi</b-form-checkbox>
 
-        <div class="mr-0 mr-md-1">
-          <b-button size="sm" title="Plot configurator" @click="showConfigurator">&#9881;</b-button>
+          <div class="ml-2">
+            <b-select
+              v-model="plotConfigName"
+              :options="availablePlotConfigNames"
+              size="sm"
+              @change="plotConfigChanged"
+            >
+            </b-select>
+          </div>
+
+          <div class="ml-2 mr-0 mr-md-1">
+            <b-button size="sm" title="Plot configurator" @click="showConfigurator">
+              &#9881;
+            </b-button>
+          </div>
         </div>
       </div>
       <div class="row mr-1 ml-1 h-100">
@@ -60,6 +66,7 @@
           :dataset="dataset"
           :trades="trades"
           :plot-config="plotConfig"
+          :heikin-ashi="heikinAshi"
           :use-u-t-c="timezone === 'UTC'"
           :theme="getChartTheme"
         >
@@ -131,6 +138,8 @@ export default class CandleChartContainer extends Vue {
   plotConfigName = '';
 
   showPlotConfig = this.plotConfigModal;
+
+  heikinAshi: boolean = false;
 
   @Getter getChartTheme!: string;
 

--- a/src/shared/formatters.ts
+++ b/src/shared/formatters.ts
@@ -112,6 +112,41 @@ export function humanizeDurationFromSeconds(duration: number): string {
   return humanizeDuration(duration * 1000);
 }
 
+export function heikinAshiDataset(columns: string[], data: Array<number[]>) {
+  const openIdx = columns.indexOf('open');
+  const closeIdx = columns.indexOf('close');
+  const highIdx = columns.indexOf('high');
+  const lowIdx = columns.indexOf('low');
+
+  // Prevent mutation of original data
+  const dataCopy = data.map((original) => original.slice());
+
+  return dataCopy.map((candle, idx, candles) => {
+    if (idx === 0) {
+      const close = (candle[openIdx] + candle[highIdx] + candle[lowIdx] + candle[closeIdx]) / 4;
+      const open = (candle[openIdx] + candle[closeIdx]) / 2;
+
+      candle[openIdx] = open;
+      candle[closeIdx] = close;
+
+      return candle;
+    }
+
+    const prevCandle = candles[idx - 1];
+    const close = (candle[openIdx] + candle[highIdx] + candle[lowIdx] + candle[closeIdx]) / 4;
+    const open = (prevCandle[openIdx] + prevCandle[closeIdx]) / 2;
+    const high = Math.max(candle[highIdx], candle[openIdx], candle[closeIdx]);
+    const low = Math.min(candle[lowIdx], candle[openIdx], candle[closeIdx]);
+
+    candle[openIdx] = open;
+    candle[closeIdx] = close;
+    candle[highIdx] = high;
+    candle[lowIdx] = low;
+
+    return candle;
+  });
+}
+
 export default {
   formatPrice,
   formatPercent,
@@ -120,4 +155,5 @@ export default {
   timestampToDateString,
   dateStringToTimeRange,
   setTimezone,
+  heikinAshiDataset,
 };

--- a/src/shared/formatters.ts
+++ b/src/shared/formatters.ts
@@ -112,41 +112,6 @@ export function humanizeDurationFromSeconds(duration: number): string {
   return humanizeDuration(duration * 1000);
 }
 
-export function heikinAshiDataset(columns: string[], data: Array<number[]>) {
-  const openIdx = columns.indexOf('open');
-  const closeIdx = columns.indexOf('close');
-  const highIdx = columns.indexOf('high');
-  const lowIdx = columns.indexOf('low');
-
-  // Prevent mutation of original data
-  const dataCopy = data.map((original) => original.slice());
-
-  return dataCopy.map((candle, idx, candles) => {
-    if (idx === 0) {
-      const close = (candle[openIdx] + candle[highIdx] + candle[lowIdx] + candle[closeIdx]) / 4;
-      const open = (candle[openIdx] + candle[closeIdx]) / 2;
-
-      candle[openIdx] = open;
-      candle[closeIdx] = close;
-
-      return candle;
-    }
-
-    const prevCandle = candles[idx - 1];
-    const close = (candle[openIdx] + candle[highIdx] + candle[lowIdx] + candle[closeIdx]) / 4;
-    const open = (prevCandle[openIdx] + prevCandle[closeIdx]) / 2;
-    const high = Math.max(candle[highIdx], candle[openIdx], candle[closeIdx]);
-    const low = Math.min(candle[lowIdx], candle[openIdx], candle[closeIdx]);
-
-    candle[openIdx] = open;
-    candle[closeIdx] = close;
-    candle[highIdx] = high;
-    candle[lowIdx] = low;
-
-    return candle;
-  });
-}
-
 export default {
   formatPrice,
   formatPercent,
@@ -155,5 +120,4 @@ export default {
   timestampToDateString,
   dateStringToTimeRange,
   setTimezone,
-  heikinAshiDataset,
 };

--- a/src/shared/heikinashi.ts
+++ b/src/shared/heikinashi.ts
@@ -1,0 +1,34 @@
+export default function heikinAshiDataset(columns: string[], data: Array<number[]>) {
+  const openIdx = columns.indexOf('open');
+  const closeIdx = columns.indexOf('close');
+  const highIdx = columns.indexOf('high');
+  const lowIdx = columns.indexOf('low');
+
+  // Prevent mutation of original data
+  const dataCopy = data.map((original) => original.slice());
+
+  return dataCopy.map((candle, idx, candles) => {
+    if (idx === 0) {
+      const close = (candle[openIdx] + candle[highIdx] + candle[lowIdx] + candle[closeIdx]) / 4;
+      const open = (candle[openIdx] + candle[closeIdx]) / 2;
+
+      candle[openIdx] = open;
+      candle[closeIdx] = close;
+
+      return candle;
+    }
+
+    const prevCandle = candles[idx - 1];
+    const close = (candle[openIdx] + candle[highIdx] + candle[lowIdx] + candle[closeIdx]) / 4;
+    const open = (prevCandle[openIdx] + prevCandle[closeIdx]) / 2;
+    const high = Math.max(candle[highIdx], candle[openIdx], candle[closeIdx]);
+    const low = Math.min(candle[lowIdx], candle[openIdx], candle[closeIdx]);
+
+    candle[openIdx] = open;
+    candle[closeIdx] = close;
+    candle[highIdx] = high;
+    candle[lowIdx] = low;
+
+    return candle;
+  });
+}

--- a/src/shared/heikinashi.ts
+++ b/src/shared/heikinashi.ts
@@ -4,10 +4,10 @@ export default function heikinAshiDataset(columns: string[], data: Array<number[
   const highIdx = columns.indexOf('high');
   const lowIdx = columns.indexOf('low');
 
-  // Prevent mutation of original data
-  const dataCopy = data.map((original) => original.slice());
+  return data.map((original, idx, candles) => {
+    // Prevent mutation of original data
+    const candle = original.slice();
 
-  return dataCopy.map((candle, idx, candles) => {
     if (idx === 0) {
       const close = (candle[openIdx] + candle[highIdx] + candle[lowIdx] + candle[closeIdx]) / 4;
       const open = (candle[openIdx] + candle[closeIdx]) / 2;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -186,7 +186,7 @@ export interface PairHistory {
   timeframe: string;
   timeframe_ms: number;
   columns: string[];
-  data: number[];
+  data: Array<number[]>;
   length: number;
   /** Number of buy signals in this response */
   buy_signals: number;


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Add an option to show the dataset in Heikin Ashi format.

The formula is taken from: https://www.investopedia.com/terms/h/heikinashi.asp

If this option proves to be used often, having it in the current place makes it very accessible.

Otherwise, having it chart configuration modal might be better so everything is in one place.

Solve the issue: #560

## Quick changelog

- Add a checkbox on CandleChartContainer for an option to show the dataset in Heikin Ashi format
- Add a formatter that transforms dataset to Heikin Ashi format

## What's new

*Explain in details what this PR solve or improve. You can include visuals.*

<!-- Please include visuals if this Pull Request changes how things look-->

![heikin-ashi](https://user-images.githubusercontent.com/11251134/157817487-a2ed6550-d9ab-4974-ad13-4ce5b0ca54b9.gif)


