### PR TITLE
add vscode extensions (developer experience)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,6 @@
 		"streetsidesoftware.code-spell-checker",
 		"vscode-icons-team.vscode-icons",
 		"hediet.vscode-drawio",
-		"naumovs.color-highlight",
 	],
 	"postCreateCommand": "yarn install",
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,8 @@
 		"marquesmps.dockerfile-validator",
 		"streetsidesoftware.code-spell-checker",
 		"vscode-icons-team.vscode-icons",
+		"hediet.vscode-drawio",
+		"naumovs.color-highlight",
 	],
 	"postCreateCommand": "yarn install",
 }


### PR DESCRIPTION
## Summary

-> help to easy maintain *.drawio file in vscode dev container (frequi store diagram).
-> help to see color straight in editor  (src/components/BotEntry.vue:7)

## Quick changelog

- add drawio extension for vscode 
- add "color highlight" extension for vscode 

## What's new

Improve developer experience

Have a nice day.