### PR TITLE
Chart trade navigation

### DIFF
--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -6,11 +6,13 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, onMounted, watch } from 'vue';
-import { Trade, PairHistory, PlotConfig } from '@/types';
+import { Trade, PairHistory, PlotConfig, ChartSliderPosition } from '@/types';
 import randomColor from '@/shared/randomColor';
 import heikinashi from '@/shared/heikinashi';
 import { getTradeEntries } from '@/shared/charts/tradeChartData';
 import ECharts from 'vue-echarts';
+import { addHours, subHours } from 'date-fns';
+import { utcToZonedTime, zonedTimeToUtc, format } from 'date-fns-tz';
 
 import { use } from 'echarts/core';
 import { EChartsOption, SeriesOption, ScatterSeriesOption } from 'echarts';
@@ -79,6 +81,7 @@ export default defineComponent({
     useUTC: { required: false, default: true, type: Boolean },
     plotConfig: { required: true, type: Object as () => PlotConfig },
     theme: { default: 'dark', type: String },
+    sliderPosition: {required: false, type: Object as () => ChartSliderPosition}
   },
   setup(props) {
     const candleChart = ref<typeof ECharts>();
@@ -634,6 +637,18 @@ export default defineComponent({
       updateChart(true);
     };
 
+    const updateSliderPosition = () => {
+      let start = format(subHours(props.sliderPosition.startValue,3),'yyyy-MM-dd HH:mm:ss');
+      let end = format(addHours(props.sliderPosition.endValue,3),'yyyy-MM-dd HH:mm:ss');
+
+      candleChart.value.dispatchAction({
+        type: 'dataZoom',
+        dataZoomIndex: 0,
+        startValue: start,
+        endValue: end
+      });
+    }
+
     // createSignalData(colDate: number, colOpen: number, colBuy: number, colSell: number): void {
     // Calculate Buy and sell Series
     // if (!this.signalsCalculated) {
@@ -671,6 +686,11 @@ export default defineComponent({
     watch(
       () => props.heikinAshi,
       () => updateChart(),
+    );
+
+    watch(
+      () => props.sliderPosition,
+      () => updateSliderPosition()
     );
 
     return {

--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -11,7 +11,6 @@ import randomColor from '@/shared/randomColor';
 import heikinashi from '@/shared/heikinashi';
 import { getTradeEntries } from '@/shared/charts/tradeChartData';
 import ECharts from 'vue-echarts';
-import { addHours, subHours } from 'date-fns';
 import { format } from 'date-fns-tz';
 
 import { use } from 'echarts/core';
@@ -644,8 +643,16 @@ export default defineComponent({
     const updateSliderPosition = () => {
       if (!props.sliderPosition) return;
 
-      const start = format(subHours(props.sliderPosition.startValue, 3), 'yyyy-MM-dd HH:mm:ss');
-      const end = format(addHours(props.sliderPosition.endValue, 3), 'yyyy-MM-dd HH:mm:ss');
+      const start = format(
+        props.sliderPosition.startValue - props.dataset.timeframe_ms * 40,
+        'yyyy-MM-dd HH:mm:ss',
+      );
+      const end = format(
+        props.sliderPosition.endValue
+          ? props.sliderPosition.endValue + props.dataset.timeframe_ms * 40
+          : props.sliderPosition.startValue + props.dataset.timeframe_ms * 80,
+        'yyyy-MM-dd HH:mm:ss',
+      );
 
       candleChart.value.dispatchAction({
         type: 'dataZoom',

--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -12,7 +12,7 @@ import heikinashi from '@/shared/heikinashi';
 import { getTradeEntries } from '@/shared/charts/tradeChartData';
 import ECharts from 'vue-echarts';
 import { addHours, subHours } from 'date-fns';
-import { utcToZonedTime, zonedTimeToUtc, format } from 'date-fns-tz';
+import { format } from 'date-fns-tz';
 
 import { use } from 'echarts/core';
 import { EChartsOption, SeriesOption, ScatterSeriesOption } from 'echarts';
@@ -81,7 +81,11 @@ export default defineComponent({
     useUTC: { required: false, default: true, type: Boolean },
     plotConfig: { required: true, type: Object as () => PlotConfig },
     theme: { default: 'dark', type: String },
-    sliderPosition: {required: false, type: Object as () => ChartSliderPosition}
+    sliderPosition: {
+      required: false,
+      type: Object as () => ChartSliderPosition,
+      default: () => undefined,
+    },
   },
   setup(props) {
     const candleChart = ref<typeof ECharts>();
@@ -638,16 +642,18 @@ export default defineComponent({
     };
 
     const updateSliderPosition = () => {
-      let start = format(subHours(props.sliderPosition.startValue,3),'yyyy-MM-dd HH:mm:ss');
-      let end = format(addHours(props.sliderPosition.endValue,3),'yyyy-MM-dd HH:mm:ss');
+      if (!props.sliderPosition) return;
+
+      const start = format(subHours(props.sliderPosition.startValue, 3), 'yyyy-MM-dd HH:mm:ss');
+      const end = format(addHours(props.sliderPosition.endValue, 3), 'yyyy-MM-dd HH:mm:ss');
 
       candleChart.value.dispatchAction({
         type: 'dataZoom',
         dataZoomIndex: 0,
         startValue: start,
-        endValue: end
+        endValue: end,
       });
-    }
+    };
 
     // createSignalData(colDate: number, colOpen: number, colBuy: number, colSell: number): void {
     // Calculate Buy and sell Series
@@ -690,7 +696,7 @@ export default defineComponent({
 
     watch(
       () => props.sliderPosition,
-      () => updateSliderPosition()
+      () => updateSliderPosition(),
     );
 
     return {

--- a/src/components/charts/CandleChartContainer.vue
+++ b/src/components/charts/CandleChartContainer.vue
@@ -71,7 +71,7 @@
           :heikin-ashi="settingsStore.useHeikinAshiCandles"
           :use-u-t-c="settingsStore.timezone === 'UTC'"
           :theme="settingsStore.chartTheme"
-          :sliderPosition="sliderPosition"
+          :slider-position="sliderPosition"
         >
         </CandleChart>
         <div v-else class="m-auto">
@@ -92,7 +92,14 @@
 </template>
 
 <script lang="ts">
-import { Trade, PairHistory, EMPTY_PLOTCONFIG, PlotConfig, LoadingStatus, ChartSliderPosition } from '@/types';
+import {
+  Trade,
+  PairHistory,
+  EMPTY_PLOTCONFIG,
+  PlotConfig,
+  LoadingStatus,
+  ChartSliderPosition,
+} from '@/types';
 import CandleChart from '@/components/charts/CandleChart.vue';
 import PlotConfigurator from '@/components/charts/PlotConfigurator.vue';
 import { getCustomPlotConfig, getPlotConfigName } from '@/shared/storage';
@@ -115,7 +122,11 @@ export default defineComponent({
     timerange: { required: false, default: '', type: String },
     /** Only required if historicView is true */
     strategy: { required: false, default: '', type: String },
-    sliderPosition: {required: false, type: Object as () => ChartSliderPosition}
+    sliderPosition: {
+      required: false,
+      type: Object as () => ChartSliderPosition,
+      default: () => undefined,
+    },
   },
   setup(props) {
     const root = getCurrentInstance();

--- a/src/components/charts/CandleChartContainer.vue
+++ b/src/components/charts/CandleChartContainer.vue
@@ -71,6 +71,7 @@
           :heikin-ashi="settingsStore.useHeikinAshiCandles"
           :use-u-t-c="settingsStore.timezone === 'UTC'"
           :theme="settingsStore.chartTheme"
+          :sliderPosition="sliderPosition"
         >
         </CandleChart>
         <div v-else class="m-auto">
@@ -91,7 +92,7 @@
 </template>
 
 <script lang="ts">
-import { Trade, PairHistory, EMPTY_PLOTCONFIG, PlotConfig, LoadingStatus } from '@/types';
+import { Trade, PairHistory, EMPTY_PLOTCONFIG, PlotConfig, LoadingStatus, ChartSliderPosition } from '@/types';
 import CandleChart from '@/components/charts/CandleChart.vue';
 import PlotConfigurator from '@/components/charts/PlotConfigurator.vue';
 import { getCustomPlotConfig, getPlotConfigName } from '@/shared/storage';
@@ -114,6 +115,7 @@ export default defineComponent({
     timerange: { required: false, default: '', type: String },
     /** Only required if historicView is true */
     strategy: { required: false, default: '', type: String },
+    sliderPosition: {required: false, type: Object as () => ChartSliderPosition}
   },
   setup(props) {
     const root = getCurrentInstance();

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -1,13 +1,13 @@
 <template>
   <b-list-group>
     <b-list-group-item
-      v-for="trade in trades"
+      v-for="trade in trades.sort((a,b) => a.open_timestamp < b.open_timestamp)"
       :key="trade.open_timestamp"
       button
       class="d-flex justify-content-between align-items-center py-1"
       :title="`${trade.pair}`"
-      :active="trade.open_timestamp === selectedTrade"
-      @click="tradeSelect(trade)"
+      :active="trade.open_timestamp === selectedTrade.open_timestamp"
+      @click="selectedTrade = trade; $emit('trade-select',trade);"
     >
       <div>
         <DateTimeTZ :date="trade.open_timestamp" />
@@ -20,6 +20,7 @@
         :stake-currency="botStore.activeBot.stakeCurrency"
       />
     </b-list-group-item>
+    <b-list-group-item v-if="trades.length === 0">No trades to show...</b-list-group-item>
   </b-list-group>
 </template>
 
@@ -36,21 +37,15 @@ export default defineComponent({
   components: { TradeProfit, ProfitPill, DateTimeTZ },
   props: {
     trades: { required: true, type: Array as () => Trade[] },
-    sortMethod: { default: 'normal', type: String },
-    backtestMode: { required: false, default: false, type: Boolean },
+    backtestMode: { required: false, default: false, type: Boolean }
   },
 
   setup(props) {
     const botStore = useBotStore();
     const selectedTrade = ref(0)
-
-    const tradeSelect = (trade: Trade) => {
-        selectedTrade.value = trade.open_timestamp;
-    }
     
     return {
       botStore,
-      tradeSelect,
       selectedTrade
     };
   },

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -1,7 +1,7 @@
 <template>
   <b-list-group>
     <b-list-group-item
-      v-for="trade in trades.sort((a,b) => a.open_timestamp < b.open_timestamp)"
+      v-for="trade in sortedTrades"
       :key="trade.open_timestamp"
       button
       class="d-flex justify-content-between align-items-center py-1"
@@ -42,11 +42,16 @@ export default defineComponent({
 
   setup(props) {
     const botStore = useBotStore();
-    const selectedTrade = ref(0)
-    
+    const selectedTrade = ref(<Trade>{});
+
+    const sortedTrades = computed(() => {
+      return props.trades.slice().sort((a,b) => b.open_timestamp - a.open_timestamp);
+    });
+
     return {
       botStore,
-      selectedTrade
+      selectedTrade,
+      sortedTrades
     };
   },
 });

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -7,7 +7,10 @@
       class="d-flex justify-content-between align-items-center py-1"
       :title="`${trade.pair}`"
       :active="trade.open_timestamp === selectedTrade.open_timestamp"
-      @click="selectedTrade = trade; $emit('trade-select',trade);"
+      @click="
+        selectedTrade = trade;
+        $emit('trade-select', trade);
+      "
     >
       <div>
         <DateTimeTZ :date="trade.open_timestamp" />
@@ -16,7 +19,7 @@
       <TradeProfit :trade="trade" />
       <ProfitPill
         v-if="backtestMode"
-        :profit-ratio="trade.profit"
+        :profit-ratio="trade.profit_ratio"
         :stake-currency="botStore.activeBot.stakeCurrency"
       />
     </b-list-group-item>
@@ -37,21 +40,21 @@ export default defineComponent({
   components: { TradeProfit, ProfitPill, DateTimeTZ },
   props: {
     trades: { required: true, type: Array as () => Trade[] },
-    backtestMode: { required: false, default: false, type: Boolean }
+    backtestMode: { required: false, default: false, type: Boolean },
   },
 
   setup(props) {
     const botStore = useBotStore();
-    const selectedTrade = ref(<Trade>{});
+    const selectedTrade = ref({} as Trade);
 
     const sortedTrades = computed(() => {
-      return props.trades.slice().sort((a,b) => b.open_timestamp - a.open_timestamp);
+      return props.trades.slice().sort((a, b) => b.open_timestamp - a.open_timestamp);
     });
 
     return {
       botStore,
       selectedTrade,
-      sortedTrades
+      sortedTrades,
     };
   },
 });

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -7,10 +7,7 @@
       class="d-flex justify-content-between align-items-center py-1"
       :title="`${trade.pair}`"
       :active="trade.open_timestamp === selectedTrade.open_timestamp"
-      @click="
-        selectedTrade = trade;
-        $emit('trade-select', trade);
-      "
+      @click="onTradeSelect(trade)"
     >
       <div>
         <DateTimeTZ :date="trade.open_timestamp" />
@@ -42,10 +39,16 @@ export default defineComponent({
     trades: { required: true, type: Array as () => Trade[] },
     backtestMode: { required: false, default: false, type: Boolean },
   },
+  emits: ['trade-select'],
 
-  setup(props) {
+  setup(props, { emit }) {
     const botStore = useBotStore();
     const selectedTrade = ref({} as Trade);
+
+    const onTradeSelect = (trade: Trade) => {
+      selectedTrade.value = trade;
+      emit('trade-select', trade);
+    };
 
     const sortedTrades = computed(() => {
       return props.trades.slice().sort((a, b) => b.open_timestamp - a.open_timestamp);
@@ -55,6 +58,7 @@ export default defineComponent({
       botStore,
       selectedTrade,
       sortedTrades,
+      onTradeSelect,
     };
   },
 });

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -1,0 +1,64 @@
+<template>
+  <b-list-group>
+    <b-list-group-item
+      v-for="trade in trades"
+      :key="trade.open_timestamp"
+      button
+      class="d-flex justify-content-between align-items-center py-1"
+      :title="`${trade.pair}`"
+      :active="trade.open_timestamp === selectedTrade"
+      @click="tradeSelect(trade)"
+    >
+      <div>
+        <DateTimeTZ :date="trade.open_timestamp" />
+      </div>
+
+      <TradeProfit :trade="trade" />
+      <ProfitPill
+        v-if="backtestMode"
+        :profit-ratio="trade.profit"
+        :stake-currency="botStore.activeBot.stakeCurrency"
+      />
+    </b-list-group-item>
+  </b-list-group>
+</template>
+
+<script lang="ts">
+import { Trade } from '@/types';
+import TradeProfit from '@/components/ftbot/TradeProfit.vue';
+import ProfitPill from '@/components/general/ProfitPill.vue';
+import { defineComponent, computed, ref } from 'vue';
+import { useBotStore } from '@/stores/ftbotwrapper';
+import DateTimeTZ from '@/components/general/DateTimeTZ.vue';
+
+export default defineComponent({
+  name: 'TradeListNav',
+  components: { TradeProfit, ProfitPill, DateTimeTZ },
+  props: {
+    trades: { required: true, type: Array as () => Trade[] },
+    sortMethod: { default: 'normal', type: String },
+    backtestMode: { required: false, default: false, type: Boolean },
+  },
+
+  setup(props) {
+    const botStore = useBotStore();
+    const selectedTrade = ref(0)
+
+    const tradeSelect = (trade: Trade) => {
+        selectedTrade.value = trade.open_timestamp;
+    }
+    
+    return {
+      botStore,
+      tradeSelect,
+      selectedTrade
+    };
+  },
+});
+</script>
+
+<style scoped>
+.list-group {
+  text-align: left;
+}
+</style>

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -6,3 +6,8 @@ export interface CumProfitData {
 export interface CumProfitDataPerDate {
   [key: number]: CumProfitData;
 }
+
+export interface ChartSliderPosition {
+  startValue: number,
+  endValue: number
+}

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -8,6 +8,6 @@ export interface CumProfitDataPerDate {
 }
 
 export interface ChartSliderPosition {
-  startValue: number,
-  endValue: number
+  startValue: number;
+  endValue: number;
 }

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -9,5 +9,5 @@ export interface CumProfitDataPerDate {
 
 export interface ChartSliderPosition {
   startValue: number;
-  endValue: number;
+  endValue: number | undefined;
 }

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -279,7 +279,7 @@
             {{ timerange }} - {{ strategy }}
           </p>
         </div>
-        <div class="col-md-1">
+        <div class="col-md-1 text-right">
           <b-button
             v-if="btFormMode === 'visualize'"
             class="right-bar-toggle"

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -286,7 +286,7 @@
             aria-label="Close"
             size="sm"
             @click="showRightBar = !showRightBar"
-            >{{ showRightBar ? '&gt;' : '&lt;'  }}
+            >{{ showRightBar ? '&gt;' : '&lt;' }}
           </b-button>
         </div>
       </div>
@@ -306,15 +306,21 @@
           :timerange="timerange"
           :strategy="strategy"
           :trades="botStore.activeBot.selectedBacktestResult.trades"
-          :class="`${showRightBar ? 'col-md-8' : 'col-md-10'} candle-chart-container px-0 w-100 h-100`"
-          :sliderPosition="sliderPosition"
+          :class="`${
+            showRightBar ? 'col-md-8' : 'col-md-10'
+          } candle-chart-container px-0 w-100 h-100`"
+          :slider-position="sliderPosition"
         >
         </CandleChartContainer>
-        <TradeListNav 
+        <TradeListNav
+          v-if="showRightBar"
           class="overflow-auto col-md-2"
           style="max-height: calc(100vh - 200px)"
-          v-if="showRightBar"
-          :trades="botStore.activeBot.selectedBacktestResult.trades.filter(t => t.pair === botStore.activeBot.selectedPair)"
+          :trades="
+            botStore.activeBot.selectedBacktestResult.trades.filter(
+              (t) => t.pair === botStore.activeBot.selectedPair,
+            )
+          "
           @trade-select="navigateChartToTrade"
         />
       </div>
@@ -364,7 +370,7 @@ export default defineComponent({
     PairSummary,
     TimeframeSelect,
     TradeList,
-    TradeListNav
+    TradeListNav,
   },
   setup() {
     const botStore = useBotStore();
@@ -395,7 +401,7 @@ export default defineComponent({
     const startingCapital = ref('');
     const btFormMode = ref('run');
     const pollInterval = ref<number | null>(null);
-    const sliderPosition = ref(<ChartSliderPosition>{});
+    const sliderPosition = ref({} as ChartSliderPosition);
 
     const setBacktestResult = (key: string) => {
       botStore.activeBot.setBacktestResultKey(key);
@@ -448,11 +454,11 @@ export default defineComponent({
       botStore.activeBot.startBacktest(btPayload);
     };
 
-    const navigateChartToTrade = (trade : Trade) => {
+    const navigateChartToTrade = (trade: Trade) => {
       sliderPosition.value = {
         startValue: trade.open_timestamp,
-        endValue: trade.close_timestamp
-      }
+        endValue: trade.close_timestamp,
+      };
     };
 
     onMounted(() => botStore.activeBot.getState());
@@ -488,7 +494,7 @@ export default defineComponent({
       btFormMode,
       clickBacktest,
       navigateChartToTrade,
-      sliderPosition
+      sliderPosition,
     };
   },
 });

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -457,7 +457,9 @@ export default defineComponent({
     const navigateChartToTrade = (trade: Trade) => {
       sliderPosition.value = {
         startValue: trade.open_timestamp,
-        endValue: trade.close_timestamp,
+        endValue: trade.close_timestamp
+          ? trade.close_timestamp
+          : trade.open_timestamp + 3 * 60 * 60 * 1000,
       };
     };
 

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -292,9 +292,20 @@
           :timerange="timerange"
           :strategy="strategy"
           :trades="botStore.activeBot.selectedBacktestResult.trades"
-          class="col-md-10 candle-chart-container px-0 w-100 h-100"
+          class="col-md-8 candle-chart-container px-0 w-100 h-100"
         >
         </CandleChartContainer>
+        <TradeListNav 
+          class="col-md-2 overflow-auto"
+          style="max-height: calc(100vh - 200px)"
+          :trades="botStore.activeBot.selectedBacktestResult.trades.filter(t => t.pair === botStore.activeBot.selectedPair)"
+        />
+        <!--<TradeList
+          class="col-md-2 overflow-auto"
+          :trades="botStore.activeBot.selectedBacktestResult.trades.filter(t => t.pair === botStore.activeBot.selectedPair)"
+          :show-filter="true"
+          :stake-currency="botStore.activeBot.selectedBacktestResult.stake_currency"
+        /> -->
       </div>
       <b-card header="Single trades" class="row mt-2 w-100">
         <TradeList
@@ -319,6 +330,7 @@ import TradesLogChart from '@/components/charts/TradesLog.vue';
 import PairSummary from '@/components/ftbot/PairSummary.vue';
 import TimeframeSelect from '@/components/ftbot/TimeframeSelect.vue';
 import TradeList from '@/components/ftbot/TradeList.vue';
+import TradeListNav from '@/components/ftbot/TradeListNav.vue';
 import BacktestHistoryLoad from '@/components/ftbot/BacktestHistoryLoad.vue';
 
 import { BacktestPayload } from '@/types';
@@ -341,6 +353,7 @@ export default defineComponent({
     PairSummary,
     TimeframeSelect,
     TradeList,
+    TradeListNav
   },
   setup() {
     const botStore = useBotStore();

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -457,9 +457,7 @@ export default defineComponent({
     const navigateChartToTrade = (trade: Trade) => {
       sliderPosition.value = {
         startValue: trade.open_timestamp,
-        endValue: trade.close_timestamp
-          ? trade.close_timestamp
-          : trade.open_timestamp + 3 * 60 * 60 * 1000,
+        endValue: trade.close_timestamp,
       };
     };
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Added column with trades for the selected pair in Visualize result and the ability to navigate to the selected trade on the chart. 

Solve the issue: #___

## Quick changelog
Not sure what to write here. 

## What's new

The summary pretty much captures the details and the feature aims to improve productivity when going over trades while backtesting.

With open trades list:
https://prnt.sc/ssqwUKnsOH5Q

With collapsed trades list:
https://prnt.sc/ibY28wRNyWxF
