### PR TITLE
Vis results modifications

### DIFF
--- a/src/components/ftbot/PairSummary.vue
+++ b/src/components/ftbot/PairSummary.vue
@@ -20,6 +20,7 @@
       <ProfitPill
         v-if="backtestMode && comb.tradeCount > 0"
         :profit-ratio="comb.profit"
+        :profit-abs="comb.profitAbs"
         :stake-currency="botStore.activeBot.stakeCurrency"
       />
     </b-list-group-item>

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -11,10 +11,7 @@
         :active="trade.open_timestamp === selectedTrade.open_timestamp"
         @click="onTradeSelect(trade)"
       >
-        <div>
-          <DateTimeTZ :date="trade.open_timestamp" />
-        </div>
-
+        <div>{{ trade.is_short ? '[S]-' : '[L]-' }}<DateTimeTZ :date="trade.open_timestamp" /></div>
         <TradeProfit :trade="trade" />
         <ProfitPill
           v-if="backtestMode"

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -11,7 +11,12 @@
         :active="trade.open_timestamp === selectedTrade.open_timestamp"
         @click="onTradeSelect(trade)"
       >
-        <div>{{ trade.is_short ? '[S]-' : '[L]-' }}<DateTimeTZ :date="trade.open_timestamp" /></div>
+        <div>
+          <span v-if="botStore.activeBot.botState.trading_mode !== 'spot'">{{
+            trade.is_short ? 'S-' : 'L-'
+          }}</span>
+          <DateTimeTZ :date="trade.open_timestamp" />
+        </div>
         <TradeProfit :trade="trade" />
         <ProfitPill
           v-if="backtestMode"


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

After using trade navigation realized it would be handy to see if the trade was a long or a short at a glance as well.

For me it would be better to see the absolute combined profit for a pair in the list too. It does make it more cluttered looking, but useful information in my eyes. 

https://prnt.sc/oFN6ltxZModJ
