### PR TITLE
Fix popover not triggering on safari

### DIFF
--- a/src/components/ftbot/TradeList.vue
+++ b/src/components/ftbot/TradeList.vue
@@ -20,7 +20,13 @@
       @row-selected="onRowSelected"
     >
       <template #cell(actions)="row">
-        <b-button :id="`btn-actions_${row.index}`" class="btn-xs" size="sm" title="Actions">
+        <b-button
+          :id="`btn-actions_${row.index}`"
+          class="btn-xs"
+          size="sm"
+          title="Actions"
+          href="#"
+        >
           <ActionIcon :size="16" title="Actions" />
         </b-button>
         <b-popover :target="`btn-actions_${row.index}`" triggers="focus" placement="left">


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Safari focus triggering required `<a>` tag. Adding href to the button component renders `<a>` tag and fixes the problem.

Solve the issue: #899 

<!-- Please include visuals if this Pull Request changes how things look-->
