### PR TITLE
fix for heikin ashi calculation

### DIFF
--- a/src/shared/heikinashi.ts
+++ b/src/shared/heikinashi.ts
@@ -4,23 +4,15 @@ export default function heikinAshiDataset(columns: string[], data: Array<number[
   const highIdx = columns.indexOf('high');
   const lowIdx = columns.indexOf('low');
 
-  return data.map((original, idx, candles) => {
+  let prevCandle: number[];
+  return data.map((original, idx) => {
     // Prevent mutation of original data
     const candle = original.slice();
-
-    if (idx === 0) {
-      const close = (candle[openIdx] + candle[highIdx] + candle[lowIdx] + candle[closeIdx]) / 4;
-      const open = (candle[openIdx] + candle[closeIdx]) / 2;
-
-      candle[openIdx] = open;
-      candle[closeIdx] = close;
-
-      return candle;
-    }
-
-    const prevCandle = candles[idx - 1];
+    const open =
+      idx === 0
+        ? (candle[openIdx] + candle[closeIdx]) / 2
+        : (prevCandle[openIdx] + prevCandle[closeIdx]) / 2;
     const close = (candle[openIdx] + candle[highIdx] + candle[lowIdx] + candle[closeIdx]) / 4;
-    const open = (prevCandle[openIdx] + prevCandle[closeIdx]) / 2;
     const high = Math.max(candle[highIdx], candle[openIdx], candle[closeIdx]);
     const low = Math.min(candle[lowIdx], candle[openIdx], candle[closeIdx]);
 
@@ -28,6 +20,8 @@ export default function heikinAshiDataset(columns: string[], data: Array<number[
     candle[closeIdx] = close;
     candle[highIdx] = high;
     candle[lowIdx] = low;
+
+    prevCandle = candle.slice();
 
     return candle;
   });


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

This PR is intended to fix HaikinAshi calculation in Frequi graph.

## Quick changelog

rework on src/shared/heikinashi.ts

## What's new

Those changes are intended to correct the way candle Open is calculeted.

actual method compute open candles based on the previous ohlcv candle and not the previous heikin ashi candle

based on the the links found in qtlibpy heikinashi method:

`
Heikin Ashi calculation: https://school.stockcharts.com/doku.php?id=chart_analysis:heikin_ashi
    ha_open calculation based on: https://stackoverflow.com/a/55110393
    ha_open = [ calculate first record ][ append remaining records with list comprehension method ]
    list comprehension method is significantly faster as a for loop
`

and especially here for the 1st candle calculation: 
https://school.stockcharts.com/doku.php?id=chart_analysis:heikin_ashi#:~:text=1.%20The%20Heikin,equals%20the%20low.

Here you can see the difference between actual and proposed open calculation.
in those screenshots qtpylib candles open is represented by pink line (sometime covered by low green when it's equal)

Actual :
you can see open are not equal:
![actual](https://user-images.githubusercontent.com/1523359/194767455-dd3596ab-8f1d-4a47-9eaf-a83321195ef8.jpg)

Proposed: 
you can see open are equals
![proposed](https://user-images.githubusercontent.com/1523359/194767464-3cd10007-55fe-4fe7-8a26-5f78b835c6e2.jpg)


