### PR TITLE
set pair to selectedPair if empty in force entry dialog

### DIFF
--- a/src/components/ftbot/BotControls.vue
+++ b/src/components/ftbot/BotControls.vue
@@ -63,7 +63,7 @@ forceexit
     >
       <PlayIcon />
     </button>
-    <ForceEntryForm @close="hideForceenter" />
+    <ForceEntryForm :pair="botStore.activeBot.selectedPair" @close="hideForceenter" />
   </div>
 </template>
 

--- a/src/components/ftbot/ForceEntryForm.vue
+++ b/src/components/ftbot/ForceEntryForm.vue
@@ -31,6 +31,7 @@
             id="pair-input"
             v-model="pair"
             required
+            :placeholder="botStore.activeBot.selectedPair"
             @keydown.enter.native="handleEntry"
           ></b-form-input>
         </b-form-group>
@@ -124,11 +125,14 @@ export default defineComponent({
       return valid;
     };
 
-    const handleSubmit = () => {
+    const handleSubmit = async () => {
+      pair.value = pair.value !== '' ? pair.value : botStore.activeBot.selectedPair;
+      await nextTick();
       // Exit when the form isn't valid
       if (!checkFormValidity()) {
         return;
       }
+
       // call forceentry
       const payload: ForceEnterPayload = { pair: pair.value };
       if (price.value) {
@@ -147,9 +151,9 @@ export default defineComponent({
         payload.leverage = leverage.value;
       }
       botStore.activeBot.forceentry(payload);
-      nextTick(() => {
-        root?.proxy.$bvModal.hide('forceentry-modal');
-      });
+
+      await nextTick();
+      root?.proxy.$bvModal.hide('forceentry-modal');
     };
     const resetForm = () => {
       console.log('resetForm');

--- a/src/components/ftbot/ForceEntryForm.vue
+++ b/src/components/ftbot/ForceEntryForm.vue
@@ -30,15 +30,10 @@
           <b-form-input
             id="pair-input"
             v-model="selectedPair"
-            list="pair-input-whitelist"
             required
             @keydown.enter.native="handleEntry"
             @focus="inputSelect"
           ></b-form-input>
-          <b-form-datalist
-            id="pair-input-whitelist"
-            :options="botStore.activeBot.whitelist"
-          ></b-form-datalist>
         </b-form-group>
         <b-form-group
           label="*Price [optional]"


### PR DESCRIPTION
## Summary
Simple QOL improvement to use the selected pair of the active bot if the user doesn't type anything in the pair field.

At first shows as a placeholder so typing something else in would be convenient. If there isn't an active pair selected acts as previously did when left empty. 
