### PR TITLE
fix select values updating with delay

### DIFF
--- a/src/stores/plotConfig.ts
+++ b/src/stores/plotConfig.ts
@@ -30,10 +30,10 @@ export const usePlotConfigStore = defineStore('plotConfig', {
       this.plotConfigName = plotConfigName;
       storePlotConfigName(plotConfigName);
     },
-    plotConfigChanged() {
+    plotConfigChanged(plotConfigName = '') {
       console.log('plotConfigChanged');
+      this.setPlotConfigName(plotConfigName ? plotConfigName : this.plotConfigName);
       this.plotConfig = getCustomPlotConfig(this.plotConfigName);
-      this.setPlotConfigName(this.plotConfigName);
     },
     setPlotConfig(plotConfig: PlotConfig) {
       console.log('emit...');


### PR DESCRIPTION
## Summary

The delay I mean is the store getting updated via v-model after the change event is fired (In CandleChartContainer b-form-select), so there ends up being a wacky experience with the plot config dropdown (on first change nothing happens, on subsequent ones changing to the one that was the previous one selected). 

So this makes the UX how it should be.