### PR TITLE
Freqai backtest

### DIFF
--- a/src/components/ftbot/FreqaiModelSelect.vue
+++ b/src/components/ftbot/FreqaiModelSelect.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <div class="w-100 d-flex">
+      <b-form-select
+        id="freqaiModel-select"
+        v-model="locFreqaiModel"
+        :options="botStore.activeBot.freqaiModelList"
+      >
+      </b-form-select>
+      <div class="ms-2">
+        <b-button @click="botStore.activeBot.getFreqAIModelList">&#x21bb;</b-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useBotStore } from '@/stores/ftbotwrapper';
+import { computed, onMounted } from 'vue';
+
+const props = defineProps({
+  modelValue: { type: String, required: true },
+});
+const emit = defineEmits(['update:modelValue']);
+const botStore = useBotStore();
+
+const locFreqaiModel = computed({
+  get() {
+    return props.modelValue;
+  },
+  set(freqaiModel: string) {
+    emit('update:modelValue', freqaiModel);
+  },
+});
+
+onMounted(() => {
+  if (botStore.activeBot.freqaiModelList.length === 0) {
+    botStore.activeBot.getFreqAIModelList();
+  }
+});
+</script>
+
+<style></style>

--- a/src/stores/ftbot.ts
+++ b/src/stores/ftbot.ts
@@ -41,6 +41,7 @@ import { showAlert } from './alerts';
 import { useWebSocket } from '@vueuse/core';
 import { FTWsMessage, FtWsMessageTypes } from '@/types/wsMessageTypes';
 import { showNotification } from '@/shared/notifications';
+import { FreqAIModelListResult } from '../types/types';
 
 export function createBotSubStore(botId: string, botName: string) {
   const userService = useUserService(botId);
@@ -81,6 +82,7 @@ export function createBotSubStore(botId: string, botName: string) {
         historyStatus: LoadingStatus.loading,
         strategyPlotConfig: undefined as PlotConfig | undefined,
         strategyList: [] as string[],
+        freqaiModelList: [] as string[],
         strategy: {} as StrategyResult,
         pairlist: [] as string[],
         currentLocks: undefined as LockResponse | undefined,
@@ -426,6 +428,16 @@ export function createBotSubStore(botId: string, botName: string) {
         try {
           const { data } = await api.get<StrategyResult>(`/strategy/${strategy}`, {});
           this.strategy = data;
+          return Promise.resolve(data);
+        } catch (error) {
+          console.error(error);
+          return Promise.reject(error);
+        }
+      },
+      async getFreqAIModelList() {
+        try {
+          const { data } = await api.get<FreqAIModelListResult>('/freqaimodels');
+          this.freqaiModelList = data.freqaimodels;
           return Promise.resolve(data);
         } catch (error) {
           console.error(error);

--- a/src/types/backtest.ts
+++ b/src/types/backtest.ts
@@ -11,6 +11,7 @@ export interface BacktestPayload {
   stake_amount?: string;
   dry_run_wallet?: number;
   enable_protections?: boolean;
+  freqaimodel?: string;
 }
 
 export interface PairResult {

--- a/src/types/backtest.ts
+++ b/src/types/backtest.ts
@@ -11,6 +11,7 @@ export interface BacktestPayload {
   stake_amount?: string;
   dry_run_wallet?: number;
   enable_protections?: boolean;
+  backtest_cache?: string;
   freqaimodel?: string;
 }
 

--- a/src/types/backtest.ts
+++ b/src/types/backtest.ts
@@ -13,6 +13,9 @@ export interface BacktestPayload {
   enable_protections?: boolean;
   backtest_cache?: string;
   freqaimodel?: string;
+  freqai?: {
+    identifier: string;
+  };
 }
 
 export interface PairResult {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -175,6 +175,10 @@ export interface StrategyResult {
   code: string;
 }
 
+export interface FreqAIModelListResult {
+  freqaimodels: string[];
+}
+
 export interface AvailablePairPayload {
   timeframe?: string;
   stake_currency?: string;

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -195,6 +195,7 @@
               ></b-form-checkbox>
             </b-form-group>
             <b-form-group
+              v-if="botStore.activeBot.botApiVersion >= 2.22"
               label-cols-sm="5"
               label="Cache Backtest results:"
               label-align-sm="right"

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -201,6 +201,14 @@
                 label-align-sm="right"
                 label-for="enable-freqai"
               >
+                <template #label>
+                  <div class="d-flex justify-content-center">
+                    <span class="me-2">Enable FreqAI:</span>
+                    <InfoBox
+                      hint="Assumes freqAI configuration is setup in the configuration, and the strategy is a freqAI strategy. Will fail if that's not the case."
+                    />
+                  </div>
+                </template>
                 <b-form-checkbox id="enable-freqai" v-model="enableFreqAI"></b-form-checkbox>
               </b-form-group>
               <FreqaiModelSelect v-if="enableFreqAI" v-model="freqaiModel"></FreqaiModelSelect>
@@ -293,6 +301,7 @@ import TimeframeSelect from '@/components/ftbot/TimeframeSelect.vue';
 import BacktestHistoryLoad from '@/components/ftbot/BacktestHistoryLoad.vue';
 import BacktestGraphsView from '@/components/ftbot/BacktestGraphsView.vue';
 import BacktestResultChart from '@/components/ftbot/BacktestResultChart.vue';
+import InfoBox from '@/components/general/InfoBox.vue';
 
 import { BacktestPayload } from '@/types';
 

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -221,6 +221,18 @@
                 <b-form-checkbox id="enable-freqai" v-model="freqAI.enabled"></b-form-checkbox>
               </b-form-group>
               <b-form-group
+                label-cols-sm="5"
+                label="FreqAI identifier:"
+                label-align-sm="right"
+                label-for="freqai-identifier"
+              >
+                <b-form-input
+                  id="freqai-identifier"
+                  v-model="freqAI.identifier"
+                  placeholder="Use config default"
+                ></b-form-input>
+              </b-form-group>
+              <b-form-group
                 v-if="freqAI.enabled"
                 label-cols-sm="5"
                 label="FreqAI Model"
@@ -349,6 +361,7 @@ const showLeftBar = ref(false);
 const freqAI = ref({
   enabled: false,
   model: '',
+  identifier: '',
 });
 const enableProtections = ref(false);
 const stakeAmountUnlimited = ref(false);
@@ -416,6 +429,9 @@ const clickBacktest = () => {
   }
   if (freqAI.value.enabled) {
     btPayload.freqaimodel = freqAI.value.model;
+    if (freqAI.value.identifier !== '') {
+      btPayload.freqai = { identifier: freqAI.value.identifier };
+    }
   }
 
   botStore.activeBot.startBacktest(btPayload);

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -209,16 +209,16 @@
                     />
                   </div>
                 </template>
-                <b-form-checkbox id="enable-freqai" v-model="enableFreqAI"></b-form-checkbox>
+                <b-form-checkbox id="enable-freqai" v-model="freqAI.enabled"></b-form-checkbox>
               </b-form-group>
               <b-form-group
-                v-if="enableFreqAI"
+                v-if="freqAI.enabled"
                 label-cols-sm="5"
                 label="FreqAI Model"
                 label-align-sm="right"
                 label-for="freqai-model"
               >
-                <FreqaiModelSelect id="freqai-model" v-model="freqaiModel"></FreqaiModelSelect>
+                <FreqaiModelSelect id="freqai-model" v-model="freqAI.model"></FreqaiModelSelect>
               </b-form-group>
             </template>
 
@@ -337,9 +337,11 @@ const selectedTimeframe = ref('');
 const selectedDetailTimeframe = ref('');
 const timerange = ref('');
 const showLeftBar = ref(false);
+const freqAI = ref({
+  enabled: false,
+  model: '',
+});
 const enableProtections = ref(false);
-const enableFreqAI = ref(false);
-const freqaiModel = ref('');
 const stakeAmountUnlimited = ref(false);
 const maxOpenTrades = ref('');
 const stakeAmount = ref('');
@@ -398,8 +400,8 @@ const clickBacktest = () => {
     // eslint-disable-next-line @typescript-eslint/camelcase
     btPayload.timeframe_detail = selectedDetailTimeframe.value;
   }
-  if (enableFreqAI.value) {
-    btPayload.freqaimodel = freqaiModel.value;
+  if (freqAI.value.enabled) {
+    btPayload.freqaimodel = freqAI.value.model;
   }
 
   botStore.activeBot.startBacktest(btPayload);

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -101,7 +101,7 @@
           <span>Strategy</span>
           <StrategySelect v-model="strategy"></StrategySelect>
         </div>
-        <b-card bg-variant="light" :disabled="botStore.activeBot.backtestRunning">
+        <b-card :disabled="botStore.activeBot.backtestRunning">
           <!-- Backtesting parameters -->
           <b-form-group
             label-cols-lg="2"

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -211,7 +211,15 @@
                 </template>
                 <b-form-checkbox id="enable-freqai" v-model="enableFreqAI"></b-form-checkbox>
               </b-form-group>
-              <FreqaiModelSelect v-if="enableFreqAI" v-model="freqaiModel"></FreqaiModelSelect>
+              <b-form-group
+                v-if="enableFreqAI"
+                label-cols-sm="5"
+                label="FreqAI Model"
+                label-align-sm="right"
+                label-for="freqai-model"
+              >
+                <FreqaiModelSelect id="freqai-model" v-model="freqaiModel"></FreqaiModelSelect>
+              </b-form-group>
             </template>
 
             <!-- <b-form-group label-cols-sm="5" label="Fee:" label-align-sm="right" label-for="fee">

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -194,6 +194,17 @@
                 v-model="enableProtections"
               ></b-form-checkbox>
             </b-form-group>
+            <template v-if="botStore.activeBot.botApiVersion >= 2.22">
+              <b-form-group
+                label-cols-sm="5"
+                label="Enable FreqAI:"
+                label-align-sm="right"
+                label-for="enable-freqai"
+              >
+                <b-form-checkbox id="enable-freqai" v-model="enableFreqAI"></b-form-checkbox>
+              </b-form-group>
+              <FreqaiModelSelect v-if="enableFreqAI" v-model="freqaiModel"></FreqaiModelSelect>
+            </template>
 
             <!-- <b-form-group label-cols-sm="5" label="Fee:" label-align-sm="right" label-for="fee">
               <b-form-input
@@ -277,6 +288,7 @@ import TimeRangeSelect from '@/components/ftbot/TimeRangeSelect.vue';
 import BacktestResultView from '@/components/ftbot/BacktestResultView.vue';
 import BacktestResultSelect from '@/components/ftbot/BacktestResultSelect.vue';
 import StrategySelect from '@/components/ftbot/StrategySelect.vue';
+import FreqaiModelSelect from '@/components/ftbot/FreqaiModelSelect.vue';
 import TimeframeSelect from '@/components/ftbot/TimeframeSelect.vue';
 import BacktestHistoryLoad from '@/components/ftbot/BacktestHistoryLoad.vue';
 import BacktestGraphsView from '@/components/ftbot/BacktestGraphsView.vue';
@@ -309,6 +321,8 @@ const selectedDetailTimeframe = ref('');
 const timerange = ref('');
 const showLeftBar = ref(false);
 const enableProtections = ref(false);
+const enableFreqAI = ref(false);
+const freqaiModel = ref('');
 const stakeAmountUnlimited = ref(false);
 const maxOpenTrades = ref('');
 const stakeAmount = ref('');
@@ -366,6 +380,9 @@ const clickBacktest = () => {
   if (selectedDetailTimeframe.value) {
     // eslint-disable-next-line @typescript-eslint/camelcase
     btPayload.timeframe_detail = selectedDetailTimeframe.value;
+  }
+  if (enableFreqAI.value) {
+    btPayload.freqaimodel = freqaiModel.value;
   }
 
   botStore.activeBot.startBacktest(btPayload);

--- a/src/views/Backtesting.vue
+++ b/src/views/Backtesting.vue
@@ -194,6 +194,14 @@
                 v-model="enableProtections"
               ></b-form-checkbox>
             </b-form-group>
+            <b-form-group
+              label-cols-sm="5"
+              label="Cache Backtest results:"
+              label-align-sm="right"
+              label-for="enable-cache"
+            >
+              <b-form-checkbox id="enable-cache" v-model="allowCache"></b-form-checkbox>
+            </b-form-group>
             <template v-if="botStore.activeBot.botApiVersion >= 2.22">
               <b-form-group
                 label-cols-sm="5"
@@ -343,6 +351,7 @@ const freqAI = ref({
 });
 const enableProtections = ref(false);
 const stakeAmountUnlimited = ref(false);
+const allowCache = ref(true);
 const maxOpenTrades = ref('');
 const stakeAmount = ref('');
 const startingCapital = ref('');
@@ -399,6 +408,10 @@ const clickBacktest = () => {
   if (selectedDetailTimeframe.value) {
     // eslint-disable-next-line @typescript-eslint/camelcase
     btPayload.timeframe_detail = selectedDetailTimeframe.value;
+  }
+  if (!allowCache.value) {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    btPayload.backtest_cache = 'none';
   }
   if (freqAI.value.enabled) {
     btPayload.freqaimodel = freqAI.value.model;


### PR DESCRIPTION
## Summary

Add new options to efficiently backtest freqAI strategies.
https://github.com/freqtrade/freqtrade/pull/7923 must be included for this to show up.

## Quick changelog

* allow  backtsting of freqAI strategies via freqUI 

## What's new

![image](https://user-images.githubusercontent.com/5024695/208742548-94c91320-aace-430b-84f5-e0330bd03d7a.png)