### PR TITLE
Visualize summary

### DIFF
--- a/src/components/charts/CumProfitChart.vue
+++ b/src/components/charts/CumProfitChart.vue
@@ -10,6 +10,7 @@ import { BarChart, LineChart } from 'echarts/charts';
 import {
   DataZoomComponent,
   DatasetComponent,
+  GridComponent,
   LegendComponent,
   TitleComponent,
   TooltipComponent,
@@ -38,6 +39,7 @@ use([
 
   DatasetComponent,
   DataZoomComponent,
+  GridComponent,
   LegendComponent,
   TitleComponent,
   TooltipComponent,


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary
A quick fix for the 'Visualize summary" tab not working in v0.9.2 backtesting mode

![Capture d’écran du 2023-06-24 16-15-53](https://github.com/freqtrade/frequi/assets/1523359/9c1f3b3a-e287-4e6f-93fd-c477cd073401)

## Quick changelog

Just import GridComponent into CumProfitChart component

## What's new

No more console blocking error and graphs are showwing again :

![Capture d’écran du 2023-06-24 16-23-20](https://github.com/freqtrade/frequi/assets/1523359/6e021f5a-290f-407d-b7d0-f87578432f14)

