### PR TITLE
Ability to see orders in trade navigation

### DIFF
--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -31,9 +31,12 @@
             :stake-currency="botStore.activeBot.stakeCurrency"
           />
         </div>
-        <b-button size="sm" @click="ordersVisible[i] = !ordersVisible[i]"
-          ><i-mdi-chevron-right v-if="!ordersVisible[i]" />
-          <i-mdi-chevron-down v-if="ordersVisible[i]" />
+        <b-button
+          size="sm"
+          variant="secondary-outline"
+          @click="ordersVisible[i] = !ordersVisible[i]"
+          ><i-mdi-chevron-right v-if="!ordersVisible[i]" width="24" height="24" />
+          <i-mdi-chevron-down v-if="ordersVisible[i]" width="24" height="24" />
         </b-button>
         <b-collapse v-model="ordersVisible[i]">
           <ul class="px-3 m-0">

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -32,15 +32,14 @@
               :stake-currency="botStore.activeBot.stakeCurrency"
             />
           </div>
-          <div class="d-flex flex-fill justify-content-end">
-            <b-button
-              size="sm"
-              variant="secondary-outline"
-              @click="ordersVisible[i] = !ordersVisible[i]"
-              ><i-mdi-chevron-right v-if="!ordersVisible[i]" width="24" height="24" />
-              <i-mdi-chevron-down v-if="ordersVisible[i]" width="24" height="24" />
-            </b-button>
-          </div>
+          <b-button
+            size="sm"
+            class="ms-auto"
+            variant="secondary-outline"
+            @click="ordersVisible[i] = !ordersVisible[i]"
+            ><i-mdi-chevron-right v-if="!ordersVisible[i]" width="24" height="24" />
+            <i-mdi-chevron-down v-if="ordersVisible[i]" width="24" height="24" />
+          </b-button>
         </div>
         <b-collapse v-model="ordersVisible[i]">
           <ul class="px-3 m-0">

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -12,32 +12,36 @@
         v-for="(trade, i) in sortedTrades"
         :key="trade.open_timestamp"
         button
-        class="d-flex flex-wrap justify-content-between align-items-center py-1"
+        class="d-flex flex-column py-1"
         :title="`${trade.pair}`"
         :active="trade.open_timestamp === selectedTrade.open_timestamp"
         @click="onTradeSelect(trade)"
       >
-        <div class="d-flex flex-column">
-          <div>
-            <span v-if="botStore.activeBot.botState.trading_mode !== 'spot'">{{
-              trade.is_short ? 'S-' : 'L-'
-            }}</span>
-            <DateTimeTZ :date="trade.open_timestamp" />
+        <div class="d-flex">
+          <div class="d-flex flex-column">
+            <div>
+              <span v-if="botStore.activeBot.botState.trading_mode !== 'spot'">{{
+                trade.is_short ? 'S-' : 'L-'
+              }}</span>
+              <DateTimeTZ :date="trade.open_timestamp" />
+            </div>
+            <TradeProfit :trade="trade" class="my-1" />
+            <ProfitPill
+              v-if="backtestMode"
+              :profit-ratio="trade.profit_ratio"
+              :stake-currency="botStore.activeBot.stakeCurrency"
+            />
           </div>
-          <TradeProfit :trade="trade" class="my-1" />
-          <ProfitPill
-            v-if="backtestMode"
-            :profit-ratio="trade.profit_ratio"
-            :stake-currency="botStore.activeBot.stakeCurrency"
-          />
+          <div class="d-flex flex-fill justify-content-end">
+            <b-button
+              size="sm"
+              variant="secondary-outline"
+              @click="ordersVisible[i] = !ordersVisible[i]"
+              ><i-mdi-chevron-right v-if="!ordersVisible[i]" width="24" height="24" />
+              <i-mdi-chevron-down v-if="ordersVisible[i]" width="24" height="24" />
+            </b-button>
+          </div>
         </div>
-        <b-button
-          size="sm"
-          variant="secondary-outline"
-          @click="ordersVisible[i] = !ordersVisible[i]"
-          ><i-mdi-chevron-right v-if="!ordersVisible[i]" width="24" height="24" />
-          <i-mdi-chevron-down v-if="ordersVisible[i]" width="24" height="24" />
-        </b-button>
         <b-collapse v-model="ordersVisible[i]">
           <ul class="px-3 m-0">
             <li

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -12,7 +12,7 @@
         v-for="(trade, i) in sortedTrades"
         :key="trade.open_timestamp"
         button
-        class="d-flex flex-column py-1"
+        class="d-flex flex-column py-1 pe-1 align-items-stretch"
         :title="`${trade.pair}`"
         :active="trade.open_timestamp === selectedTrade.open_timestamp"
         @click="onTradeSelect(trade)"


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Added the ability to see all filled orders for a trade in the trade navigation list, might be useful for others as well?

https://i.imgur.com/VvkLVt3.png
