### PR TITLE
Feat/backtest comments

### DIFF
--- a/cypress/fixtures/backtest/backtest_get_end.json
+++ b/cypress/fixtures/backtest/backtest_get_end.json
@@ -6,7 +6,13 @@
     "progress": 1.0,
     "trade_count": null,
     "backtest_result": {
-        "metadata": {},
+        "metadata": {
+            "SampleStrategy": {
+                "strategy": "SampleStrategy",
+                "run_id": "0afc3cf414b6da90210f458078a6b06055b0c4e7",
+                "filename": "backtest-result-2023-08-03_04-02-20"
+            }
+        },
         "strategy": {
             "SampleStrategy": {
                 "trades": [

--- a/src/components/ftbot/BacktestHistoryLoad.vue
+++ b/src/components/ftbot/BacktestHistoryLoad.vue
@@ -23,6 +23,11 @@
         <strong>{{ res.strategy }}</strong>
         backtested on: {{ timestampms(res.backtest_start_time * 1000) }}
         <small>{{ res.filename }}</small>
+        <InfoBox
+          v-if="botStore.activeBot.botApiVersion >= 2.32"
+          :class="res.notes ? 'opacity-100' : 'opacity-0'"
+          :hint="res.notes ?? ''"
+        ></InfoBox>
         <b-button
           v-if="botStore.activeBot.botApiVersion >= 2.31"
           class="ms-1"
@@ -44,6 +49,7 @@ import MessageBox, { MsgBoxObject } from '@/components/general/MessageBox.vue';
 import { timestampms } from '@/shared/formatters';
 import { useBotStore } from '@/stores/ftbotwrapper';
 import { BacktestHistoryEntry } from '@/types';
+import InfoBox from '../general/InfoBox.vue';
 
 const botStore = useBotStore();
 const msgBox = ref<typeof MessageBox>();

--- a/src/components/ftbot/BacktestHistoryLoad.vue
+++ b/src/components/ftbot/BacktestHistoryLoad.vue
@@ -12,12 +12,13 @@
       Load Historic results from disk. You can click on multiple results to load all of them into
       freqUI.
     </p>
-    <b-list-group v-if="botStore.activeBot.backtestHistoryList" class="ms-2">
+    <b-list-group v-if="botStore.activeBot.backtestHistoryList" class="ms-2 mb-1">
       <b-list-group-item
         v-for="(res, idx) in botStore.activeBot.backtestHistoryList"
         :key="idx"
-        class="d-flex justify-content-between align-items-center py-1 mb-1"
+        class="d-flex justify-content-between align-items-center py-1"
         button
+        :disabled="res.run_id in botStore.activeBot.backtestHistory"
         @click="botStore.activeBot.getBacktestHistoryResult(res)"
       >
         <strong>{{ res.strategy }}</strong>
@@ -33,6 +34,7 @@
           class="ms-1"
           size="sm"
           title="Delete this Result."
+          :disabled="res.run_id in botStore.activeBot.backtestHistory"
           @click.stop="deleteBacktestResult(res)"
         >
           <i-mdi-delete />

--- a/src/components/ftbot/BacktestResultSelect.vue
+++ b/src/components/ftbot/BacktestResultSelect.vue
@@ -11,7 +11,7 @@
         @click="setBacktestResult(key)"
       >
         <template v-if="!result.metadata.editing">
-          <div class="d-flex flex-column me-2">
+          <div class="d-flex flex-column me-2 text-start">
             <div class="fw-bold">
               {{ result.metadata.strategyName }} - {{ result.strategy.timeframe }}
             </div>
@@ -19,7 +19,7 @@
               TradeCount: {{ result.strategy.total_trades }} - Profit:
               {{ formatPercent(result.strategy.profit_total) }}
             </div>
-            <div v-if="canUseModify" class="text-small">
+            <div v-if="canUseModify" class="text-small" style="white-space: pre-wrap">
               {{ result.metadata.notes }}
             </div>
           </div>
@@ -36,8 +36,8 @@
           </b-button>
         </template>
         <template v-if="result.metadata.editing">
-          <b-form-input v-model="result.metadata.notes" placeholder="notes" size="sm">
-          </b-form-input>
+          <b-form-textarea v-model="result.metadata.notes" placeholder="notes" size="sm">
+          </b-form-textarea>
 
           <b-button size="sm" title="Confirm" @click.stop="confirmInput(key, result)">
             <i-mdi-check />

--- a/src/components/ftbot/BacktestResultSelect.vue
+++ b/src/components/ftbot/BacktestResultSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container d-flex flex-column align-items-center">
+  <div class="container d-flex flex-column align-items-stretch">
     <h3>Available results:</h3>
     <b-list-group class="ms-2">
       <b-list-group-item
@@ -23,17 +23,25 @@
               {{ result.metadata.notes }}
             </div>
           </div>
-          <b-button
-            v-if="canUseModify"
-            size="sm"
-            title="Modify"
-            @click.stop="result.metadata.editing = !result.metadata.editing"
-          >
-            <i-mdi-pencil />
-          </b-button>
-          <b-button size="sm" title="Delete this Result." @click.stop="emit('removeResult', key)">
-            <i-mdi-delete />
-          </b-button>
+          <div class="d-flex">
+            <b-button
+              v-if="canUseModify"
+              class="flex-nowrap"
+              size="sm"
+              title="Modify"
+              @click.stop="result.metadata.editing = !result.metadata.editing"
+            >
+              <i-mdi-pencil />
+            </b-button>
+            <b-button
+              size="sm"
+              class="flex-nowrap"
+              title="Delete this Result."
+              @click.stop="emit('removeResult', key)"
+            >
+              <i-mdi-delete />
+            </b-button>
+          </div>
         </template>
         <template v-if="result.metadata.editing">
           <b-form-textarea v-model="result.metadata.notes" placeholder="notes" size="sm">

--- a/src/components/ftbot/BacktestResultSelect.vue
+++ b/src/components/ftbot/BacktestResultSelect.vue
@@ -19,7 +19,7 @@
               TradeCount: {{ result.strategy.total_trades }} - Profit:
               {{ formatPercent(result.strategy.profit_total) }}
             </div>
-            <div class="text-small">
+            <div v-if="canUseModify" class="text-small">
               {{ result.metadata.notes }}
             </div>
           </div>

--- a/src/components/ftbot/BacktestResultSelect.vue
+++ b/src/components/ftbot/BacktestResultSelect.vue
@@ -10,23 +10,41 @@
         class="d-flex justify-content-between align-items-center py-1 pe-1"
         @click="setBacktestResult(key)"
       >
-        <div class="d-flex flex-column">
-          <div class="fw-bold">
-            {{ result.metadata.strategyName }} - {{ result.strategy.timeframe }}
+        <template v-if="!result.metadata.editing">
+          <div class="d-flex flex-column me-2">
+            <div class="fw-bold">
+              {{ result.metadata.strategyName }} - {{ result.strategy.timeframe }}
+            </div>
+            <div class="text-small">
+              TradeCount: {{ result.strategy.total_trades }} - Profit:
+              {{ formatPercent(result.strategy.profit_total) }}
+            </div>
+            <div class="text-small">
+              {{ result.metadata.notes }}
+            </div>
           </div>
-          <div class="text-small">
-            TradeCount: {{ result.strategy.total_trades }} - Profit:
-            {{ formatPercent(result.strategy.profit_total) }}
-          </div>
-        </div>
-        <b-button
-          class="ms-2"
-          size="sm"
-          title="Delete this Result."
-          @click.stop="emit('removeResult', key)"
-        >
-          <i-mdi-delete />
-        </b-button>
+          <b-button
+            size="sm"
+            title="Modify"
+            @click.stop="result.metadata.editing = !result.metadata.editing"
+          >
+            <i-mdi-pencil />
+          </b-button>
+          <b-button size="sm" title="Delete this Result." @click.stop="emit('removeResult', key)">
+            <i-mdi-delete />
+          </b-button>
+        </template>
+        <template v-if="result.metadata.editing">
+          <b-form-input v-model="result.metadata.notes" size="sm"> </b-form-input>
+
+          <b-button
+            size="sm"
+            title="Confirm"
+            @click.stop="result.metadata.editing = !result.metadata.editing"
+          >
+            <i-mdi-check />
+          </b-button>
+        </template>
       </b-list-group-item>
     </b-list-group>
   </div>
@@ -35,8 +53,9 @@
 <script setup lang="ts">
 import { formatPercent } from '@/shared/formatters';
 import { BacktestResultInMemory } from '@/types';
+import { ref } from 'vue';
 
-defineProps({
+const props = defineProps({
   backtestHistory: {
     required: true,
     type: Object as () => Record<string, BacktestResultInMemory>,

--- a/src/components/ftbot/BacktestResultSelect.vue
+++ b/src/components/ftbot/BacktestResultSelect.vue
@@ -24,6 +24,7 @@
             </div>
           </div>
           <b-button
+            v-if="canUseModify"
             size="sm"
             title="Modify"
             @click.stop="result.metadata.editing = !result.metadata.editing"
@@ -56,6 +57,7 @@ defineProps({
     type: Object as () => Record<string, BacktestResultInMemory>,
   },
   selectedBacktestResultKey: { required: false, default: '', type: String },
+  canUseModify: { required: false, default: false, type: Boolean },
 });
 const emit = defineEmits<{
   selectionChange: [value: string];

--- a/src/components/ftbot/BacktestResultSelect.vue
+++ b/src/components/ftbot/BacktestResultSelect.vue
@@ -37,11 +37,7 @@
         <template v-if="result.metadata.editing">
           <b-form-input v-model="result.metadata.notes" size="sm"> </b-form-input>
 
-          <b-button
-            size="sm"
-            title="Confirm"
-            @click.stop="result.metadata.editing = !result.metadata.editing"
-          >
+          <b-button size="sm" title="Confirm" @click.stop="confirmInput(key, result)">
             <i-mdi-check />
           </b-button>
         </template>
@@ -52,10 +48,9 @@
 
 <script setup lang="ts">
 import { formatPercent } from '@/shared/formatters';
-import { BacktestResultInMemory } from '@/types';
-import { ref } from 'vue';
+import { BacktestResultInMemory, BacktestResultUpdate } from '@/types';
 
-const props = defineProps({
+defineProps({
   backtestHistory: {
     required: true,
     type: Object as () => Record<string, BacktestResultInMemory>,
@@ -65,11 +60,24 @@ const props = defineProps({
 const emit = defineEmits<{
   selectionChange: [value: string];
   removeResult: [value: string];
+  updateResult: [value: BacktestResultUpdate];
 }>();
 
 const setBacktestResult = (key: string) => {
   emit('selectionChange', key);
 };
+
+function confirmInput(run_id: string, result: BacktestResultInMemory) {
+  result.metadata.editing = !result.metadata.editing;
+  if (result.metadata.filename) {
+    emit('updateResult', {
+      run_id: run_id,
+      notes: result.metadata.notes ?? '',
+      filename: result.metadata.filename,
+      strategy: result.metadata.strategyName,
+    });
+  }
+}
 </script>
 
 <style scoped></style>

--- a/src/components/ftbot/BacktestResultSelect.vue
+++ b/src/components/ftbot/BacktestResultSelect.vue
@@ -36,7 +36,8 @@
           </b-button>
         </template>
         <template v-if="result.metadata.editing">
-          <b-form-input v-model="result.metadata.notes" size="sm"> </b-form-input>
+          <b-form-input v-model="result.metadata.notes" placeholder="notes" size="sm">
+          </b-form-input>
 
           <b-button size="sm" title="Confirm" @click.stop="confirmInput(key, result)">
             <i-mdi-check />

--- a/src/stores/ftbot.ts
+++ b/src/stores/ftbot.ts
@@ -900,7 +900,6 @@ export function createBotSubStore(botId: string, botName: string) {
       },
       updateBacktestResult(backtestResult: BacktestResult) {
         this.backtestResult = backtestResult;
-        // TODO: Properly identify duplicates to avoid pushing the same multiple times
         Object.entries(backtestResult.strategy).forEach(([key, strat]) => {
           const metadata: BacktestMetadataWithStrategyName = {
             ...(backtestResult.metadata[key] ?? {}),

--- a/src/stores/ftbot.ts
+++ b/src/stores/ftbot.ts
@@ -903,6 +903,8 @@ export function createBotSubStore(botId: string, botName: string) {
           const metadata: BacktestMetadataWithStrategyName = {
             ...(backtestResult.metadata[key] ?? {}),
             strategyName: key,
+            notes: backtestResult.metadata[key]?.notes ?? ``,
+            editing: false,
           };
           // console.log(key, strat, metadata);
 

--- a/src/styles/_styles_ovw.scss
+++ b/src/styles/_styles_ovw.scss
@@ -80,6 +80,12 @@
         background: $bg-dark;
     }
 
+    .list-group-item.disabled,
+    .list-group-item:disabled {
+        color: darken($fg-color, 40%);
+        background: $bg-dark;
+    }
+
     // .custom-select {
     //     color: $fg-color;
     //     // background: $bg-dark;

--- a/src/types/backtest.ts
+++ b/src/types/backtest.ts
@@ -196,6 +196,16 @@ export interface BacktestMetadataWithStrategyName extends BacktestMetadata {
   editing: boolean;
 }
 
+export interface BacktestMetadataPatch {
+  notes: string;
+  strategy: string;
+}
+
+export interface BacktestResultUpdate extends BacktestMetadataPatch {
+  run_id: string;
+  filename: string;
+}
+
 /**
  * Represents the in-memory result of a backtest.
  */

--- a/src/types/backtest.ts
+++ b/src/types/backtest.ts
@@ -186,6 +186,7 @@ export interface BacktestMetadata {
   /** Start time of the backtest run */
   backtest_run_start_ts: number;
   run_id: string;
+  filename?: string;
   notes?: string;
 }
 

--- a/src/types/backtest.ts
+++ b/src/types/backtest.ts
@@ -186,10 +186,13 @@ export interface BacktestMetadata {
   /** Start time of the backtest run */
   backtest_run_start_ts: number;
   run_id: string;
+  notes?: string;
 }
 
+/** Only used in memory */
 export interface BacktestMetadataWithStrategyName extends BacktestMetadata {
   strategyName: string;
+  editing: boolean;
 }
 
 /**

--- a/src/types/backtest.ts
+++ b/src/types/backtest.ts
@@ -244,4 +244,5 @@ export interface BacktestHistoryEntry {
   strategy: string;
   run_id: string;
   backtest_start_time: number;
+  notes?: string;
 }

--- a/src/views/BacktestingView.vue
+++ b/src/views/BacktestingView.vue
@@ -87,6 +87,7 @@
             :selected-backtest-result-key="botStore.activeBot.selectedBacktestResultKey"
             @selection-change="botStore.activeBot.setBacktestResultKey"
             @remove-result="botStore.activeBot.removeBacktestResultFromMemory"
+            @update-result="botStore.activeBot.saveBacktestResultMetadata"
           />
         </transition>
       </div>

--- a/src/views/BacktestingView.vue
+++ b/src/views/BacktestingView.vue
@@ -85,6 +85,7 @@
             v-if="btFormMode !== 'visualize' && showLeftBar"
             :backtest-history="botStore.activeBot.backtestHistory"
             :selected-backtest-result-key="botStore.activeBot.selectedBacktestResultKey"
+            :can-use-modify="botStore.activeBot.botApiVersion >= 2.32"
             @selection-change="botStore.activeBot.setBacktestResultKey"
             @remove-result="botStore.activeBot.removeBacktestResultFromMemory"
             @update-result="botStore.activeBot.saveBacktestResultMetadata"


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Add "notes" capability to backtest results.
Will require the very latest develop, which includes https://github.com/freqtrade/freqtrade/pull/9013 to work properly, otherwise prior behavior is kept.

Closes #1353

## Quick changelog

* Allow notes in "available results" section, which are persisted in the strategy's metadata file
* disable already loaded backtest results - to avoid tripple-clicking the same result



![image](https://github.com/freqtrade/frequi/assets/5024695/85c0197e-fe62-4ce3-8520-2c15eda3a771)

![image](https://github.com/freqtrade/frequi/assets/5024695/ec06fcef-bf5a-458b-9d3c-c9ba838568b5)

