### PR TITLE
fix selected plot config overwritten by new or duplicate

### DIFF
--- a/src/components/charts/PlotConfigurator.vue
+++ b/src/components/charts/PlotConfigurator.vue
@@ -357,6 +357,7 @@ watch(
   () => {
     selIndicatorName.value = '';
     // selSubPlot.value = '';
+    plotConfigNameLoc.value = plotStore.plotConfigName;
   },
 );
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Noticed a bug when creating or duplicating a new plot config, and clicking save on that replaced the original config, instead of saving the new one. 