### PR TITLE
Unplugin-vue-components autoimport

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,9 +8,6 @@
 </template>
 
 <script setup lang="ts">
-import NavBar from '@/components/layout/NavBar.vue';
-import NavFooter from '@/components/layout/NavFooter.vue';
-import BodyLayout from '@/components/layout/BodyLayout.vue';
 import { setTimezone } from './shared/formatters';
 import { onMounted, watch } from 'vue';
 import { useSettingsStore } from './stores/settings';

--- a/src/components/BotList.vue
+++ b/src/components/BotList.vue
@@ -35,8 +35,6 @@
 </template>
 
 <script setup lang="ts">
-import BotEntry from '@/components/BotEntry.vue';
-import BotRename from '@/components/BotRename.vue';
 import LoginModal from '@/views/LoginModal.vue';
 
 import { useBotStore } from '@/stores/ftbotwrapper';

--- a/src/components/charts/CandleChartContainer.vue
+++ b/src/components/charts/CandleChartContainer.vue
@@ -101,9 +101,6 @@
 </template>
 
 <script setup lang="ts">
-import CandleChart from '@/components/charts/CandleChart.vue';
-import PlotConfigSelect from '@/components/charts/PlotConfigSelect.vue';
-import PlotConfigurator from '@/components/charts/PlotConfigurator.vue';
 import { usePlotConfigStore } from '@/stores/plotConfig';
 import { useSettingsStore } from '@/stores/settings';
 import { ChartSliderPosition, LoadingStatus, PairHistory, Trade } from '@/types';

--- a/src/components/charts/PlotConfigSelect.vue
+++ b/src/components/charts/PlotConfigSelect.vue
@@ -21,7 +21,6 @@
 </template>
 
 <script setup lang="ts">
-import EditValue from '@/components/general/EditValue.vue';
 import { usePlotConfigStore } from '@/stores/plotConfig';
 
 defineProps({

--- a/src/components/charts/PlotConfigurator.vue
+++ b/src/components/charts/PlotConfigurator.vue
@@ -156,12 +156,8 @@
 </template>
 
 <script setup lang="ts">
-import EditValue from '@/components/general/EditValue.vue';
-import PlotConfigSelect from '@/components/charts/PlotConfigSelect.vue';
-import PlotIndicator from '@/components/charts/PlotIndicator.vue';
 import { showAlert } from '@/shared/alerts';
 import { IndicatorConfig, PlotConfig } from '@/types';
-import PlotIndicatorSelect from './PlotIndicatorSelect.vue';
 
 import { deepClone } from '@/shared/deepClone';
 import { useBotStore } from '@/stores/ftbotwrapper';

--- a/src/components/charts/PlotIndicator.vue
+++ b/src/components/charts/PlotIndicator.vue
@@ -44,7 +44,6 @@
 <script setup lang="ts">
 import { ChartType, IndicatorConfig } from '@/types';
 import randomColor from '@/shared/randomColor';
-import PlotIndicatorSelect from '@/components/charts/PlotIndicatorSelect.vue';
 import { computed, ref, watch } from 'vue';
 import { watchDebounced } from '@vueuse/core';
 

--- a/src/components/ftbot/BacktestGraphs.vue
+++ b/src/components/ftbot/BacktestGraphs.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
 import { ClosedTrade } from '@/types';
-import ProfitDistributionChart from '@/components/charts/ProfitDistributionChart.vue';
-import CumProfitChart from '@/components/charts/CumProfitChart.vue';
-import TradesLogChart from '@/components/charts/TradesLog.vue';
 
 defineProps({
   trades: { required: true, type: Array as () => ClosedTrade[] },

--- a/src/components/ftbot/BacktestResultAnalysis.vue
+++ b/src/components/ftbot/BacktestResultAnalysis.vue
@@ -50,7 +50,6 @@
 
 <script setup lang="ts">
 import { StrategyBacktestResult } from '@/types';
-import BacktestResultPeriodBreakdown from './BacktestResultPeriodBreakdown.vue';
 import { formatObjectForTable } from '@/shared/objectToTableItems';
 
 import { computed } from 'vue';

--- a/src/components/ftbot/BacktestResultAnalysis.vue
+++ b/src/components/ftbot/BacktestResultAnalysis.vue
@@ -49,7 +49,6 @@
 </template>
 
 <script setup lang="ts">
-import TradeList from '@/components/ftbot/TradeList.vue';
 import { StrategyBacktestResult } from '@/types';
 import BacktestResultPeriodBreakdown from './BacktestResultPeriodBreakdown.vue';
 import { formatObjectForTable } from '@/shared/objectToTableItems';

--- a/src/components/ftbot/BacktestResultChart.vue
+++ b/src/components/ftbot/BacktestResultChart.vue
@@ -72,10 +72,6 @@
 
 <script setup lang="ts">
 import { useBotStore } from '@/stores/ftbotwrapper';
-import TradeList from '@/components/ftbot/TradeList.vue';
-import TradeListNav from '@/components/ftbot/TradeListNav.vue';
-import PairSummary from '@/components/ftbot/PairSummary.vue';
-import CandleChartContainer from '@/components/charts/CandleChartContainer.vue';
 import { ref } from 'vue';
 import { ChartSliderPosition, Trade } from '@/types';
 

--- a/src/components/ftbot/BacktestResultComparison.vue
+++ b/src/components/ftbot/BacktestResultComparison.vue
@@ -34,7 +34,6 @@ import { formatObjectForTable } from '@/shared/objectToTableItems';
 import { computed } from 'vue';
 import { generateBacktestMetricRows } from '@/shared/backtestMetrics';
 import { TableField } from 'bootstrap-vue-next';
-import BacktestResultSelectEntry from '@/components/ftbot/BacktestResultSelectEntry.vue';
 
 const props = defineProps({
   backtestResults: { required: true, type: Object as () => Record<string, BacktestResultInMemory> },

--- a/src/components/ftbot/BacktestResultSelect.vue
+++ b/src/components/ftbot/BacktestResultSelect.vue
@@ -47,7 +47,6 @@
 
 <script setup lang="ts">
 import { BacktestResultInMemory, BacktestResultUpdate } from '@/types';
-import BacktestResultSelectEntry from '@/components/ftbot/BacktestResultSelectEntry.vue';
 
 defineProps({
   backtestHistory: {

--- a/src/components/ftbot/BacktestRun.vue
+++ b/src/components/ftbot/BacktestRun.vue
@@ -199,14 +199,6 @@
 </template>
 
 <script setup lang="ts">
-import TimeRangeSelect from '@/components/ftbot/TimeRangeSelect.vue';
-
-import FreqaiModelSelect from '@/components/ftbot/FreqaiModelSelect.vue';
-import StrategySelect from '@/components/ftbot/StrategySelect.vue';
-import TimeframeSelect from '@/components/ftbot/TimeframeSelect.vue';
-
-import InfoBox from '@/components/general/InfoBox.vue';
-
 import { useBotStore } from '@/stores/ftbotwrapper';
 import { BacktestPayload } from '@/types';
 

--- a/src/components/ftbot/BotBalance.vue
+++ b/src/components/ftbot/BotBalance.vue
@@ -61,7 +61,6 @@
 </template>
 
 <script setup lang="ts">
-import BalanceChart from '@/components/charts/BalanceChart.vue';
 import { formatPercent, formatPrice } from '@/shared/formatters';
 import { useBotStore } from '@/stores/ftbotwrapper';
 import { BalanceValues } from '@/types';

--- a/src/components/ftbot/BotComparisonList.vue
+++ b/src/components/ftbot/BotComparisonList.vue
@@ -69,7 +69,6 @@
 </template>
 
 <script setup lang="ts">
-import ProfitPill from '@/components/general/ProfitPill.vue';
 import { formatPrice } from '@/shared/formatters';
 import { computed } from 'vue';
 import { useBotStore } from '@/stores/ftbotwrapper';

--- a/src/components/ftbot/BotProfit.vue
+++ b/src/components/ftbot/BotProfit.vue
@@ -9,7 +9,6 @@
 
 <script setup lang="ts">
 import { formatPercent, formatPriceCurrency, timestampms } from '@/shared/formatters';
-import DateTimeTZ from '@/components/general/DateTimeTZ.vue';
 
 import { ProfitInterface } from '@/types';
 import { TableField, TableItem } from 'bootstrap-vue-next';

--- a/src/components/ftbot/BotStatus.vue
+++ b/src/components/ftbot/BotStatus.vue
@@ -86,10 +86,8 @@
 </template>
 
 <script setup lang="ts">
-import DateTimeTZ from '@/components/general/DateTimeTZ.vue';
 import { formatPercent, formatPriceCurrency } from '@/shared/formatters';
 
-import BotProfit from '@/components/ftbot/BotProfit.vue';
 import { useBotStore } from '@/stores/ftbotwrapper';
 
 const botStore = useBotStore();

--- a/src/components/ftbot/CustomTradeList.vue
+++ b/src/components/ftbot/CustomTradeList.vue
@@ -35,7 +35,6 @@
 
 <script setup lang="ts">
 import { Trade } from '@/types';
-import CustomTradeListEntry from '@/components/ftbot/CustomTradeListEntry.vue';
 import { computed, ref } from 'vue';
 import { useBotStore } from '@/stores/ftbotwrapper';
 

--- a/src/components/ftbot/CustomTradeListEntry.vue
+++ b/src/components/ftbot/CustomTradeListEntry.vue
@@ -17,7 +17,6 @@
 
 <script setup lang="ts">
 import { Trade } from '@/types';
-import DateTimeTZ from '@/components/general/DateTimeTZ.vue';
 import TradeProfit from './TradeProfit.vue';
 
 defineProps({

--- a/src/components/ftbot/PairSummary.vue
+++ b/src/components/ftbot/PairSummary.vue
@@ -32,8 +32,6 @@
 <script setup lang="ts">
 import { formatPercent, timestampms } from '@/shared/formatters';
 import { Lock, Trade } from '@/types';
-import TradeProfit from '@/components/ftbot/TradeProfit.vue';
-import ProfitPill from '@/components/general/ProfitPill.vue';
 import { computed, ref } from 'vue';
 import { useBotStore } from '@/stores/ftbotwrapper';
 

--- a/src/components/ftbot/PairlistConfigItem.vue
+++ b/src/components/ftbot/PairlistConfigItem.vue
@@ -55,7 +55,6 @@
 </template>
 
 <script setup lang="ts">
-import PairlistConfigParameter from '@/components/ftbot/PairlistConfigParameter.vue';
 import { usePairlistConfigStore } from '@/stores/pairlistConfig';
 import { Pairlist } from '@/types';
 import { computed } from 'vue';

--- a/src/components/ftbot/PairlistConfigResults.vue
+++ b/src/components/ftbot/PairlistConfigResults.vue
@@ -44,7 +44,6 @@ import { ref, watch } from 'vue';
 import { useBotStore } from '@/stores/ftbotwrapper';
 import { usePairlistConfigStore } from '@/stores/pairlistConfig';
 import ChartView from '@/views/ChartsView.vue';
-import CopyableTextfield from '@/components/general/CopyableTextfield.vue';
 
 const botStore = useBotStore();
 const pairlistStore = usePairlistConfigStore();

--- a/src/components/ftbot/PairlistConfigurator.vue
+++ b/src/components/ftbot/PairlistConfigurator.vue
@@ -99,7 +99,6 @@ import PairlistConfigBlacklist from './PairlistConfigBlacklist.vue';
 import PairlistConfigActions from './PairlistConfigActions.vue';
 import { Pairlist } from '@/types';
 import { useSortable, moveArrayElement } from '@vueuse/integrations/useSortable';
-import CopyableTextfield from '@/components/general/CopyableTextfield.vue';
 import ExchangeSelect from './ExchangeSelect.vue';
 
 const botStore = useBotStore();

--- a/src/components/ftbot/PeriodBreakdown.vue
+++ b/src/components/ftbot/PeriodBreakdown.vue
@@ -33,7 +33,6 @@
 </template>
 
 <script setup lang="ts">
-import TimePeriodChart from '@/components/charts/TimePeriodChart.vue';
 import { formatPercent, formatPrice } from '@/shared/formatters';
 import { useBotStore } from '@/stores/ftbotwrapper';
 import { TableField } from 'bootstrap-vue-next';

--- a/src/components/ftbot/TradeDetail.vue
+++ b/src/components/ftbot/TradeDetail.vue
@@ -130,9 +130,6 @@
 
 <script setup lang="ts">
 import { formatPercent, formatPriceCurrency, formatPrice, timestampms } from '@/shared/formatters';
-import ValuePair from '@/components/general/ValuePair.vue';
-import TradeProfit from '@/components/ftbot/TradeProfit.vue';
-import DateTimeTZ from '@/components/general/DateTimeTZ.vue';
 import { Trade } from '@/types';
 
 defineProps({

--- a/src/components/ftbot/TradeList.vue
+++ b/src/components/ftbot/TradeList.vue
@@ -88,10 +88,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { formatPercent, formatPrice } from '@/shared/formatters';
 import { MultiDeletePayload, MultiForcesellPayload, Trade } from '@/types';
-import DateTimeTZ from '@/components/general/DateTimeTZ.vue';
-import TradeProfit from './TradeProfit.vue';
-import TradeActionsPopover from './TradeActionsPopover.vue';
-import ForceExitForm from '@/components/ftbot/ForceExitForm.vue';
 
 import { ref, computed, watch, onMounted } from 'vue';
 import { useBotStore } from '@/stores/ftbotwrapper';

--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -59,11 +59,8 @@
 
 <script setup lang="ts">
 import { Trade } from '@/types';
-import TradeProfit from '@/components/ftbot/TradeProfit.vue';
-import ProfitPill from '@/components/general/ProfitPill.vue';
 import { computed, ref, watch } from 'vue';
 import { useBotStore } from '@/stores/ftbotwrapper';
-import DateTimeTZ from '@/components/general/DateTimeTZ.vue';
 
 const props = defineProps({
   trades: { required: true, type: Array as () => Trade[] },

--- a/src/components/ftbot/TradeProfit.vue
+++ b/src/components/ftbot/TradeProfit.vue
@@ -10,7 +10,6 @@
 <script setup lang="ts">
 import { formatPercent, timestampms } from '@/shared/formatters';
 import { Trade } from '@/types';
-import ProfitPill from '@/components/general/ProfitPill.vue';
 
 import { computed, PropType } from 'vue';
 

--- a/src/components/general/ProfitPill.vue
+++ b/src/components/general/ProfitPill.vue
@@ -22,8 +22,6 @@
 <script setup lang="ts">
 import { formatPercent, formatPrice, formatPriceCurrency } from '@/shared/formatters';
 
-import ProfitSymbol from '@/components/general/ProfitSymbol.vue';
-
 import { computed } from 'vue';
 
 const props = defineProps({

--- a/src/components/general/ValuePair.vue
+++ b/src/components/general/ValuePair.vue
@@ -11,8 +11,6 @@
 </template>
 
 <script setup lang="ts">
-import InfoBox from '@/components/general/InfoBox.vue';
-
 defineProps({
   description: { type: String, required: true },
   help: { type: String, default: '', required: false },

--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -133,11 +133,7 @@
 
 <script setup lang="ts">
 import LoginModal from '@/views/LoginModal.vue';
-import ThemeSelect from '@/components/ThemeSelect.vue';
 import Favico from 'favico.js';
-import ReloadControl from '@/components/ftbot/ReloadControl.vue';
-import BotEntry from '@/components/BotEntry.vue';
-import BotList from '@/components/BotList.vue';
 import { ref, onBeforeUnmount, onMounted, watch } from 'vue';
 import { OpenTradeVizOptions, useSettingsStore } from '@/stores/settings';
 import { useLayoutStore } from '@/stores/layout';

--- a/src/views/BacktestingView.vue
+++ b/src/views/BacktestingView.vue
@@ -152,14 +152,6 @@
 </template>
 
 <script setup lang="ts">
-import BacktestGraphs from '@/components/ftbot/BacktestGraphs.vue';
-import BacktestHistoryLoad from '@/components/ftbot/BacktestHistoryLoad.vue';
-import BacktestResultChart from '@/components/ftbot/BacktestResultChart.vue';
-import BacktestResultSelect from '@/components/ftbot/BacktestResultSelect.vue';
-import BacktestResultAnalysis from '@/components/ftbot/BacktestResultAnalysis.vue';
-import BacktestResultComparison from '@/components/ftbot/BacktestResultComparison.vue';
-import BacktestRun from '@/components/ftbot/BacktestRun.vue';
-
 import { formatPercent } from '@/shared/formatters';
 import { useBtStore } from '@/stores/btStore';
 import { useBotStore } from '@/stores/ftbotwrapper';

--- a/src/views/ChartsView.vue
+++ b/src/views/ChartsView.vue
@@ -40,10 +40,6 @@
 </template>
 
 <script setup lang="ts">
-import CandleChartContainer from '@/components/charts/CandleChartContainer.vue';
-import TimeRangeSelect from '@/components/ftbot/TimeRangeSelect.vue';
-import TimeframeSelect from '@/components/ftbot/TimeframeSelect.vue';
-import StrategySelect from '@/components/ftbot/StrategySelect.vue';
 import { onMounted, ref } from 'vue';
 import { useBotStore } from '@/stores/ftbotwrapper';
 

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -159,15 +159,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
 
-import TimePeriodChart from '@/components/charts/TimePeriodChart.vue';
-import CumProfitChart from '@/components/charts/CumProfitChart.vue';
-import TradesLogChart from '@/components/charts/TradesLog.vue';
-import ProfitDistributionChart from '@/components/charts/ProfitDistributionChart.vue';
-import BotComparisonList from '@/components/ftbot/BotComparisonList.vue';
-import TradeList from '@/components/ftbot/TradeList.vue';
-import DraggableContainer from '@/components/layout/DraggableContainer.vue';
-import InfoBox from '@/components/general/InfoBox.vue';
-
 import { DashboardLayout, findGridLayout, useLayoutStore } from '@/stores/layout';
 import { useBotStore } from '@/stores/ftbotwrapper';
 import { GridItemData } from '@/types';

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -20,9 +20,7 @@
   </div>
 </template>
 
-<script setup lang="ts">
-import BotList from '@/components/BotList.vue';
-</script>
+<script setup lang="ts"></script>
 
 <style lang="scss" scoped>
 .home {

--- a/src/views/LogView.vue
+++ b/src/views/LogView.vue
@@ -4,8 +4,6 @@
   </div>
 </template>
 
-<script setup lang="ts">
-import LogViewer from '@/components/ftbot/LogViewer.vue';
-</script>
+<script setup lang="ts"></script>
 
 <style scoped></style>

--- a/src/views/LoginModal.vue
+++ b/src/views/LoginModal.vue
@@ -7,7 +7,7 @@
       title="Login to your bot"
       @ok="handleOk"
     >
-      <login
+      <BotLogin
         ref="loginForm"
         in-modal
         :existing-auth="loginInfo"
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-import Login from '@/components/BotLogin.vue';
+import BotLogin from '@/components/BotLogin.vue';
 import { AuthStorageWithBotId } from '@/types';
 import { nextTick, ref } from 'vue';
 
@@ -26,7 +26,7 @@ defineProps({
   loginText: { required: false, default: 'Login', type: String },
 });
 const loginViewOpen = ref(false);
-const loginForm = ref<typeof Login>();
+const loginForm = ref<typeof BotLogin>();
 const loginInfo = ref<AuthStorageWithBotId | undefined>(undefined);
 const handleLoginResult = (result: boolean) => {
   if (result) {

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -6,9 +6,7 @@
   </div>
 </template>
 
-<script setup lang="ts">
-import BotLogin from '@/components/BotLogin.vue';
-</script>
+<script setup lang="ts"></script>
 
 <style scoped>
 .container {

--- a/src/views/PairlistConfigView.vue
+++ b/src/views/PairlistConfigView.vue
@@ -2,6 +2,4 @@
   <PairlistConfigurator class="pt-4" />
 </template>
 
-<script setup lang="ts">
-import PairlistConfigurator from '@/components/ftbot/PairlistConfigurator.vue';
-</script>
+<script setup lang="ts"></script>

--- a/src/views/TradesListView.vue
+++ b/src/views/TradesListView.vue
@@ -41,8 +41,6 @@
 </template>
 
 <script setup lang="ts">
-import CustomTradeList from '@/components/ftbot/CustomTradeList.vue';
-import TradeDetail from '@/components/ftbot/TradeDetail.vue';
 import { useBotStore } from '@/stores/ftbotwrapper';
 
 defineProps({

--- a/src/views/TradingView.vue
+++ b/src/views/TradingView.vue
@@ -43,7 +43,7 @@
               <BotPerformance class="performance-view" />
             </b-tab>
             <b-tab title="Balance" lazy>
-              <Balance />
+              <BotBalance />
             </b-tab>
             <b-tab title="Time Breakdown" lazy>
               <PeriodBreakdown />
@@ -147,19 +147,6 @@
 
 <script setup lang="ts">
 import { GridItemData } from '@/types';
-
-import Balance from '@/components/ftbot/BotBalance.vue';
-import BotControls from '@/components/ftbot/BotControls.vue';
-import BotStatus from '@/components/ftbot/BotStatus.vue';
-import CandleChartContainer from '@/components/charts/CandleChartContainer.vue';
-import PeriodBreakdown from '@/components/ftbot/PeriodBreakdown.vue';
-import DraggableContainer from '@/components/layout/DraggableContainer.vue';
-import PairListLive from '@/components/ftbot/PairListLive.vue';
-import PairLockList from '@/components/ftbot/PairLockList.vue';
-import PairSummary from '@/components/ftbot/PairSummary.vue';
-import BotPerformance from '@/components/ftbot/BotPerformance.vue';
-import TradeDetail from '@/components/ftbot/TradeDetail.vue';
-import TradeList from '@/components/ftbot/TradeList.vue';
 
 import { ref, computed } from 'vue';
 import { useLayoutStore, findGridLayout, TradeLayout } from '@/stores/layout';

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
     }),
     Components({
       resolvers: [IconsResolve(), BootstrapVueNextResolver()],
-      dirs: [],
+      // dirs: [],
       dts: true,
     }),
     Icons({


### PR DESCRIPTION
## Summary

Fully use unplugin-vue-components potential to auto-import our components.


## Quick changelog

- Update config
- Remove Imports