### PR TITLE
Type props in pct tool

### DIFF
--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -9,6 +9,7 @@ import { generateAreaCandleSeries, generateCandleSeries } from '@/shared/charts/
 import heikinashi from '@/shared/charts/heikinashi';
 import { generateTradeSeries } from '@/shared/charts/tradeChartData';
 import {
+  CandleChartProps,
   ChartSliderPosition,
   ChartType,
   IndicatorConfig,
@@ -76,6 +77,7 @@ const MARGINRIGHT = '1%';
 const NAMEGAP = 55;
 const SUBPLOTHEIGHT = 8; // Value in %
 
+/*
 const props = defineProps({
   trades: { required: false, default: () => [], type: Array as () => Trade[] },
   dataset: { required: true, type: Object as () => PairHistory },
@@ -90,6 +92,15 @@ const props = defineProps({
   },
   colorUp: { required: false, type: String, default: '#12bb7b' },
   colorDown: { required: false, type: String, default: '#ef5350' },
+});*/
+
+const props = withDefaults(defineProps<CandleChartProps>(), {
+  trades: () => [],
+  heikinAshi: false,
+  useUTC: true,
+  sliderPosition: undefined,
+  colorUp: '#12bb7b',
+  colorDown: '#ef5350',
 });
 
 // Candle Colors

--- a/src/composables/percentageTool.ts
+++ b/src/composables/percentageTool.ts
@@ -1,8 +1,9 @@
 import { ElementEvent } from 'echarts';
 import { ROUND_CLOSER, roundTimeframe } from '@/shared/timemath';
 import humanizeDuration from 'humanize-duration';
+import { CandleChartProps } from '@/types';
 
-export function usePercentageTool(chartRef, props) {
+export function usePercentageTool(chartRef, props: CandleChartProps) {
   const inputListener = useKeyModifier('Shift', { events: ['keydown', 'keyup'] });
 
   const color = computed(() => (props.theme === 'dark' ? 'white' : 'black'));

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -1,3 +1,7 @@
+import { PlotConfig } from './plot';
+import { Trade } from './trades';
+import { PairHistory } from './types';
+
 export interface CumProfitData {
   [date: string]: number;
   profit: number;
@@ -16,4 +20,16 @@ export type CumProfitChartData = {
 export interface ChartSliderPosition {
   startValue: number;
   endValue: number | undefined;
+}
+
+export interface CandleChartProps {
+  trades?: Trade[];
+  dataset: PairHistory;
+  heikinAshi?: boolean;
+  useUTC?: boolean;
+  plotConfig: PlotConfig;
+  theme: string;
+  sliderPosition?: ChartSliderPosition;
+  colorUp?: string;
+  colorDown?: string;
 }


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary
I was left bothered a bit that the props parameter in usePercentageTool wasn't properly typed. To do it though, I think how props are defined in CandleChart.vue needs to be changed to something like in this PR, basically export an interface. 

<!-- Please include visuals if this Pull Request changes how things look-->
