### PR TITLE
fix(BotProfit.vue): fix incorrect ROI metric

### DIFF
--- a/src/components/ftbot/BotProfit.vue
+++ b/src/components/ftbot/BotProfit.vue
@@ -28,7 +28,7 @@ const profitItems = computed<TableItem[]>(() => {
   if (!props.profit) return [];
   return [
     {
-      metric: 'ROI open trades',
+      metric: 'ROI closed trades',
       value: props.profit.profit_closed_coin
         ? `${formatPriceCurrency(
             props.profit.profit_closed_coin,


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Freq UI Trade view was incorrectly displaying `ROI open trades` with incorrect values. The correct metric to display is the `ROI closed trades` value.

This was solved by changing the metric name to `ROI closed trades` which is consistent with metrics on the Telegram `/profit` command and the metric on the dashboard.

