### PR TITLE
pnpm run install -->  pnpm install. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Ports can vary, so check the URL you're using.
 ### Project setup
 
 ```
-pnpm run install
+pnpm install
 ```
 
 ### Compiles and hot-reloads for development


### PR DESCRIPTION
There is no target in package.json defining install. Instead what is meant is the pnpm command 'install'

<!-- Thank you for sending your pull request. -->

## Summary

To correct an error in the readme regarding the command to install frequi's dependencies.

Solve the issue: # 1965

## Quick changelog

- See the readme

## What's new

*Explain in details what this PR solve or improve. You can include visuals.*

A minor typographical, syntactical improvement.
