### PR TITLE
Add sorting trades by profit

### DIFF
--- a/src/components/ftbot/TradeListNav.vue
+++ b/src/components/ftbot/TradeListNav.vue
@@ -11,7 +11,12 @@ const emit = defineEmits<{ 'trade-select': [trade: Trade] }>();
 
 const botStore = useBotStore();
 const selectedTrade = ref({} as Trade);
-const sortNewestFirst = ref(true);
+const sortDescendingOrder = ref(true)
+const sortMethod = ref('openDate')
+const sortMethodOptions = [
+  {text: 'Open date', value: 'openDate'},
+  {text: 'Profit', value: 'profit'},
+]
 
 const onTradeSelect = (trade: Trade) => {
   selectedTrade.value = trade;
@@ -19,13 +24,23 @@ const onTradeSelect = (trade: Trade) => {
 };
 
 const sortedTrades = computed(() => {
-  return props.trades
-    .slice()
-    .sort((a, b) =>
-      sortNewestFirst.value
-        ? b.open_timestamp - a.open_timestamp
-        : a.open_timestamp - b.open_timestamp,
-    );
+  if (sortMethod.value === 'profit') {
+    return props.trades
+      .slice()
+      .sort((a, b) =>
+        sortDescendingOrder.value    
+          ? b.profit_ratio - a.profit_ratio
+          : a.profit_ratio - b.profit_ratio,
+    )
+  } else {
+    return props.trades
+      .slice()
+      .sort((a, b) =>
+        sortDescendingOrder.value
+          ? b.open_timestamp - a.open_timestamp
+          : a.open_timestamp - b.open_timestamp,
+      );
+  }
 });
 
 const ordersVisible = ref(sortedTrades.value.map(() => false));
@@ -40,13 +55,21 @@ watch(
 
 <template>
   <div>
+    <div class="d-flex justify-content-center">
+      <span class="me-2">Sort by:</span>
+      <BFormRadioGroup
+        v-model="sortMethod"
+        :options="sortMethodOptions"
+        name="radio-options"
+      />
+    </div>
     <BListGroup>
       <BListGroupItem
         button
         class="d-flex flex-wrap justify-content-center align-items-center"
         :title="'Trade Navigation'"
-        @click="sortNewestFirst = !sortNewestFirst"
-        >Trade Navigation {{ sortNewestFirst ? '&#8595;' : '&#8593;' }}
+        @click="sortDescendingOrder = !sortDescendingOrder"
+        >Trade Navigation {{ sortDescendingOrder ? '&#8595;' : '&#8593;' }}
       </BListGroupItem>
       <BListGroupItem
         v-for="(trade, i) in sortedTrades"


### PR DESCRIPTION
It can be useful when I want to quickly find the best winning or worst losing trades.

<img width="429" alt="截屏2024-10-15 16 17 27" src="https://github.com/user-attachments/assets/d8c101e4-25b5-489a-9cc2-a0d36db56a02">
