### PR TITLE
Fix trade select

### DIFF
--- a/src/components/charts/CandleChart.vue
+++ b/src/components/charts/CandleChart.vue
@@ -649,12 +649,10 @@ function initializeChartOptions() {
 function updateSliderPosition() {
   if (!props.sliderPosition) return;
 
-  const start = timestampms(props.sliderPosition.startValue - props.dataset.timeframe_ms * 40);
-  const end = timestampms(
-    props.sliderPosition.endValue
-      ? props.sliderPosition.endValue + props.dataset.timeframe_ms * 40
-      : props.sliderPosition.startValue + props.dataset.timeframe_ms * 80,
-  );
+  const start = props.sliderPosition.startValue - props.dataset.timeframe_ms * 40;
+  const end = props.sliderPosition.endValue
+    ? props.sliderPosition.endValue + props.dataset.timeframe_ms * 40
+    : props.sliderPosition.startValue + props.dataset.timeframe_ms * 80;
   if (candleChart.value) {
     candleChart.value.dispatchAction({
       type: 'dataZoom',


### PR DESCRIPTION
When I select a trade in "Trade Navigation" (backtest visualize result), the trade is located in the chart "randomly" and sometimes outside the range. After some investigation, I found that the problem might be related to timezone. Let me explain it:

We pass the time with the format of "2024-01-01 01:00:00" (UTC) to ECharts, but according to [ECharts documentation](https://echarts.apache.org/en/option.html#series-line.data)
> a subset of [ISO 8601](https://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15), only including (all of these are treated as local time unless timezone is specified, which is consistent with [moment](https://momentjs.com/))

They are interpreted as in my local timezone (GMT+8)

So we might consider modifying the string format to something like "2024-01-01T01:00:00Z" or simply passing the timestamp in milliseconds.