### PR TITLE
Fix cost currency sign

### DIFF
--- a/src/utils/charts/tradeChartData.ts
+++ b/src/utils/charts/tradeChartData.ts
@@ -3,7 +3,7 @@ import { Order, PairHistory, Trade, BTOrder } from '@/types';
 import { ScatterSeriesOption } from 'echarts';
 
 function buildTooltipCost(order: Order | BTOrder, quoteCurrency: string): string {
-  return `${order.ft_order_side === 'buy' ? '+' : '-'}${formatPriceCurrency(
+  return `${order.ft_order_side === 'buy' ? '-' : '+'}${formatPriceCurrency(
     'cost' in order ? order.cost : order.amount * order.safe_price,
     quoteCurrency,
   )}`;


### PR DESCRIPTION
<img width="241" alt="截屏2024-10-17 06 42 09" src="https://github.com/user-attachments/assets/06b739f7-04aa-455f-89e3-3b052ccf264e">
<img width="234" alt="截屏2024-10-17 06 42 18" src="https://github.com/user-attachments/assets/ee03e27c-2361-4db6-9bd3-3c7def3e3876">

I am not sure if it's intentional, but intuitively (for spot trading) we -$344 when we buy, and +$348 when we sell, right?