### PR TITLE
chore: run ci against node 23, drop running against 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        node: [ "18", "20", "21", "22"]
+        node: [ "18", "20", "22", "23"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Run CI against supported node versions.

21 ended support 6 months ago, and security support 4 months ago.
Add running CI against node 23.