### PR TITLE
feat: add support to chagne scatter symbol size

### DIFF
--- a/src/components/charts/PlotIndicator.vue
+++ b/src/components/charts/PlotIndicator.vue
@@ -3,6 +3,8 @@ import { ChartType, ChartTypeString, IndicatorConfig } from '@/types';
 
 import { watchDebounced } from '@vueuse/core';
 
+const DEFAULT_SCATTER_SYMBOL_SIZE = 3;
+
 const props = defineProps({
   modelValue: { required: true, type: Object as () => Record<string, IndicatorConfig> },
   columns: { required: true, type: Array as () => string[] },
@@ -16,6 +18,7 @@ const availableGraphTypes = ref<ChartTypeString[]>(Object.keys(ChartType) as Cha
 const selAvailableIndicator = ref('');
 const cancelled = ref(false);
 const fillTo = ref('');
+const scatterSymbolSize = ref(DEFAULT_SCATTER_SYMBOL_SIZE);
 
 function newColor() {
   selColor.value = randomColor();
@@ -31,6 +34,9 @@ const combinedIndicator = computed<IndicatorConfig>(() => {
   };
   if (fillTo.value && graphType.value === ChartType.line) {
     val.fill_to = fillTo.value;
+  }
+  if (graphType.value == ChartType.scatter) {
+    val.scatterSymbolSize = scatterSymbolSize.value;
   }
   return {
     [selAvailableIndicator.value]: val,
@@ -59,7 +65,7 @@ watch(
 );
 
 watchDebounced(
-  [selColor, graphType, fillTo],
+  [selColor, graphType, fillTo, scatterSymbolSize],
   () => {
     emitIndicator();
   },
@@ -108,5 +114,12 @@ watchDebounced(
       class="mt-1"
       label="Area chart - Fill to (leave empty for line chart)"
     />
+    <BFormGroup
+      v-if="graphType === ChartType.scatter"
+      label="Scatter symbol size"
+      label-class="mt-1"
+    >
+      <BFormSpinbutton v-model="scatterSymbolSize" />
+    </BFormGroup>
   </div>
 </template>

--- a/src/types/plot.ts
+++ b/src/types/plot.ts
@@ -10,6 +10,7 @@ export interface IndicatorConfig {
   color?: string;
   type?: ChartType | ChartTypeString;
   fill_to?: string;
+  scatterSymbolSize?: number;
 }
 
 export interface PlotConfig {

--- a/src/utils/charts/candleChartSeries.ts
+++ b/src/utils/charts/candleChartSeries.ts
@@ -24,6 +24,12 @@ export function generateCandleSeries(
     },
     showSymbol: false,
   };
+  if (value.type === ChartType.scatter) {
+    sp['symbolSize'] = value.scatterSymbolSize;
+    sp['emphasis'] = {
+      disabled: true,
+    };
+  }
   return sp;
 }
 


### PR DESCRIPTION
Currently we use the echarts default symbol size (10px) when plotting scatter indicators. This PR changes the default symbol size to 3px and adds a spin button to adjust the value.

*Before:*
<img width="624" alt="截屏2024-10-18 04 21 56" src="https://github.com/user-attachments/assets/e00951bf-908e-422a-aa56-5b9880333e06">
*After:*
<img width="624" alt="截屏2024-10-18 04 22 53" src="https://github.com/user-attachments/assets/20e8d3da-f7fc-4b84-96e3-33f018a1f9d4">
<img width="488" alt="截屏2024-10-18 04 23 09" src="https://github.com/user-attachments/assets/c1be4019-c143-4a92-8c8c-baccc4c9a4ca">
