### PR TITLE
fix: Prepend '#' to the picked colors value missing the prefix

### DIFF
--- a/src/components/charts/PlotIndicator.vue
+++ b/src/components/charts/PlotIndicator.vue
@@ -51,6 +51,11 @@ watch(
     cancelled.value = false;
     if (selAvailableIndicator.value && props.modelValue) {
       const xx = props.modelValue[selAvailableIndicator.value];
+      if (!xx.color.startsWith('#') &&
+        (xx.color.length === 3 || xx.color.length === 6) &&
+        /^[0-9a-fA-F]+$/.test(xx.color)) {
+        xx.color = `#${xx.color}`;
+      }
       selColor.value = xx.color || randomColor();
       graphType.value = xx.type || ChartType.line;
       fillTo.value = xx.fill_to || '';

--- a/src/components/charts/PlotIndicator.vue
+++ b/src/components/charts/PlotIndicator.vue
@@ -9,7 +9,20 @@ const props = defineProps({
 
 const emit = defineEmits<{ 'update:modelValue': [value: IndicatorConfig] }>();
 
-const selColor = ref(randomColor());
+const selColor_ = ref(randomColor());
+const selColor = computed({
+  get: () => selColor_.value,
+  set: (val) => {
+    if (
+      !val.startsWith('#') &&
+      (val.length === 3 || val.length === 6) &&
+      /^[0-9a-fA-F]+$/.test(val)
+    ) {
+      val = `#${val}`;
+    }
+    selColor_.value = val;
+  },
+});
 const graphType = ref<ChartTypeString>(ChartType.line);
 const availableGraphTypes = ref<ChartTypeString[]>(Object.keys(ChartType) as ChartTypeString[]);
 const selAvailableIndicator = ref('');
@@ -51,11 +64,6 @@ watch(
     cancelled.value = false;
     if (selAvailableIndicator.value && props.modelValue) {
       const xx = props.modelValue[selAvailableIndicator.value];
-      if (!xx.color.startsWith('#') &&
-        (xx.color.length === 3 || xx.color.length === 6) &&
-        /^[0-9a-fA-F]+$/.test(xx.color)) {
-        xx.color = `#${xx.color}`;
-      }
       selColor.value = xx.color || randomColor();
       graphType.value = xx.type || ChartType.line;
       fillTo.value = xx.fill_to || '';


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary

Fixes the color picker not including the `#` prefix on the hex colors which causes the chart to behave incorrect, for `line` type the color will be green and on chart hover the line will disappear, and on type `bar` the color will be incorrect but it wont disappear on hovering.

here is an example with a line type
![image](https://github.com/user-attachments/assets/e1a0cdfc-9cd7-468a-9e8b-f768813e7082)
and when hovering it
![image](https://github.com/user-attachments/assets/497e1a3c-2a16-4b95-9ca6-b7796e04f0f5)
and here is how the bar type looks
![image](https://github.com/user-attachments/assets/668ef31d-36a5-4379-946d-b09a7664906a)

Solve the issue: check if the value of the `xx.color` is a valid hex color value that doesn't have the `#` prefix and just add it in `xx.color`.

<!-- Please include visuals if this Pull Request changes how things look-->
