### PR TITLE
Update Node.js versions in CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        node: [ "18", "20", "22", "23", "24" ]
+        node: [ "20", "22", "23", "24" ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        node: [ "18", "20", "22", "23"]
+        node: [ "18", "20", "22", "23", "24" ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Run tests against Node.js 24 and remove CI support for deprecated Node.js 18.