### PR TITLE
chore: bump echarts to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "deepmerge": "^4.3.1",
-    "echarts": "^5.6.0",
+    "echarts": "^6.0.0",
     "favico.js": "^0.3.10",
     "humanize-duration": "^3.33.1",
     "pinia": "3.0.3",
@@ -34,7 +34,7 @@
     "primevue": "^4.3.9",
     "sortablejs": "^1.15.6",
     "vue": "^3.5.21",
-    "vue-echarts": "^7.0.3",
+    "vue-echarts": "^8.0.0-beta.2",
     "vue-router": "^4.5.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
       echarts:
-        specifier: ^5.6.0
-        version: 5.6.0
+        specifier: ^6.0.0
+        version: 6.0.0
       favico.js:
         specifier: ^0.3.10
         version: 0.3.10
@@ -60,8 +60,8 @@ importers:
         specifier: ^3.5.21
         version: 3.5.21(typescript@5.8.3)
       vue-echarts:
-        specifier: ^7.0.3
-        version: 7.0.3(@vue/runtime-core@3.5.21)(echarts@5.6.0)(vue@3.5.21(typescript@5.8.3))
+        specifier: ^8.0.0-beta.2
+        version: 8.0.0-beta.2(echarts@6.0.0)(vue@3.5.21(typescript@5.8.3))
       vue-router:
         specifier: ^4.5.1
         version: 4.5.1(vue@3.5.21(typescript@5.8.3))
@@ -1387,8 +1387,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  echarts@5.6.0:
-    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+  echarts@6.0.0:
+    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
 
   editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
@@ -2446,26 +2446,11 @@ packages:
   vue-component-type-helpers@2.2.8:
     resolution: {integrity: sha512-4bjIsC284coDO9om4HPA62M7wfsTvcmZyzdfR0aUlFXqq4tXxM1APyXpNVxPC8QazKw9OhmZNHBVDA6ODaZsrA==}
 
-  vue-demi@0.13.11:
-    resolution: {integrity: sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==}
-    engines: {node: '>=12'}
-    hasBin: true
+  vue-echarts@8.0.0-beta.2:
+    resolution: {integrity: sha512-ZZzdknCvY5iuuSZzjFeDoLwFuJru131vDO0oqP1rL6TJp3g7WyC3vJ5f1ZbuwrOZ7y0umL0/T8IVLrh/mKM9Jw==}
     peerDependencies:
-      '@vue/composition-api': ^1.0.0-rc.1
-      vue: ^3.0.0-0 || ^2.6.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-
-  vue-echarts@7.0.3:
-    resolution: {integrity: sha512-/jSxNwOsw5+dYAUcwSfkLwKPuzTQ0Cepz1LxCOpj2QcHrrmUa/Ql0eQqMmc1rTPQVrh2JQ29n2dhq75ZcHvRDw==}
-    peerDependencies:
-      '@vue/runtime-core': ^3.0.0
-      echarts: ^5.5.1
-      vue: ^2.7.0 || ^3.1.1
-    peerDependenciesMeta:
-      '@vue/runtime-core':
-        optional: true
+      echarts: ^6.0.0
+      vue: ^3.3.0
 
   vue-eslint-parser@10.2.0:
     resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
@@ -2541,8 +2526,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zrender@5.6.1:
-    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+  zrender@6.0.0:
+    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
 snapshots:
 
@@ -3698,10 +3683,10 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  echarts@5.6.0:
+  echarts@6.0.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 5.6.1
+      zrender: 6.0.0
 
   editorconfig@1.0.4:
     dependencies:
@@ -4738,19 +4723,10 @@ snapshots:
 
   vue-component-type-helpers@2.2.8: {}
 
-  vue-demi@0.13.11(vue@3.5.21(typescript@5.8.3)):
+  vue-echarts@8.0.0-beta.2(echarts@6.0.0)(vue@3.5.21(typescript@5.8.3)):
     dependencies:
+      echarts: 6.0.0
       vue: 3.5.21(typescript@5.8.3)
-
-  vue-echarts@7.0.3(@vue/runtime-core@3.5.21)(echarts@5.6.0)(vue@3.5.21(typescript@5.8.3)):
-    dependencies:
-      echarts: 5.6.0
-      vue: 3.5.21(typescript@5.8.3)
-      vue-demi: 0.13.11(vue@3.5.21(typescript@5.8.3))
-    optionalDependencies:
-      '@vue/runtime-core': 3.5.21
-    transitivePeerDependencies:
-      - '@vue/composition-api'
 
   vue-eslint-parser@10.2.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
@@ -4827,6 +4803,6 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zrender@5.6.1:
+  zrender@6.0.0:
     dependencies:
       tslib: 2.3.0


### PR DESCRIPTION
<!-- Thank you for sending your pull request. -->

## Summary
Bump echarts and vue-echarts to 6.0.0 and 8.0.0-beta.2 respectively