### PR TITLE
CORS/axios api login was not including credentials

### DIFF
--- a/src/composables/loginInfo.ts
+++ b/src/composables/loginInfo.ts
@@ -112,6 +112,7 @@ export function useLoginInfo(botId: string) {
       {},
       {
         auth: { ...auth },
+        withCredentials: true,
       },
     );
     if (data.access_token && data.refresh_token) {

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -54,7 +54,9 @@ export const useSettingsStore = defineStore('uiSettings', {
     async loadUIVersion() {
       if (import.meta.env.PROD) {
         try {
-          const result = await axios.get<UiVersion>('/ui_version');
+          const result = await axios.get<UiVersion>('/ui_version', {
+            withCredentials: true,
+          });
           const { version } = result.data;
           this._uiVersion = version ?? 'dev';
         } catch (error) {


### PR DESCRIPTION
## Summary

Login requests, when CORS was setup, did not send authentication data (Cookies) with the XHR request.

## Quick changelog

- fix: CORS/axios api login was not including credentials

## What's new

* `loginCall` using `axios.post` now has `withCredentials: true` set. And properly submits auxilliary authentication data (e.g. Cookies). 

NOTE: Unsure if this is the right place, as I have seen it setup in `api.ts` but, somehow it does not work.