### PR TITLE
Add timeframe switching support to candle chart

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -225,6 +225,7 @@ declare global {
   const useCountdown: typeof import('@vueuse/core').useCountdown
   const useCounter: typeof import('@vueuse/core').useCounter
   const useCssModule: typeof import('vue').useCssModule
+  const useCssSupports: typeof import('@vueuse/core').useCssSupports
   const useCssVar: typeof import('@vueuse/core').useCssVar
   const useCssVars: typeof import('vue').useCssVars
   const useCurrentElement: typeof import('@vueuse/core').useCurrentElement
@@ -632,6 +633,7 @@ declare module 'vue' {
     readonly useCountdown: UnwrapRef<typeof import('@vueuse/core')['useCountdown']>
     readonly useCounter: UnwrapRef<typeof import('@vueuse/core')['useCounter']>
     readonly useCssModule: UnwrapRef<typeof import('vue')['useCssModule']>
+    readonly useCssSupports: UnwrapRef<typeof import('@vueuse/core')['useCssSupports']>
     readonly useCssVar: UnwrapRef<typeof import('@vueuse/core')['useCssVar']>
     readonly useCssVars: UnwrapRef<typeof import('vue')['useCssVars']>
     readonly useCurrentElement: UnwrapRef<typeof import('@vueuse/core')['useCurrentElement']>

--- a/src/components/ftbot/BacktestResultChart.vue
+++ b/src/components/ftbot/BacktestResultChart.vue
@@ -11,6 +11,7 @@ const props = defineProps<{
 const botStore = useBotStore();
 const isBarVisible = ref({ right: true, left: true });
 const sliderPosition = ref<ChartSliderPosition>();
+const selectedTimeframe = ref(props.timeframe);
 
 function navigateChartToTrade(trade: Trade) {
   sliderPosition.value = {
@@ -22,7 +23,7 @@ function navigateChartToTrade(trade: Trade) {
 function refreshOHLCV(pair: string, columns: string[]) {
   botStore.activeBot.getPairHistory({
     pair: pair,
-    timeframe: props.timeframe,
+    timeframe: selectedTimeframe.value,
     timerange: props.timerange,
     strategy: props.strategy,
     freqaimodel: props.freqaiModel,
@@ -92,13 +93,15 @@ onMounted(() => {
         :available-pairs="backtestResult.pairlist"
         historic-view
         reload-data-on-switch
-        :timeframe="timeframe"
+        v-model:timeframe="selectedTimeframe"
         :timerange="timerange"
         :strategy="strategy"
         :trades="backtestResult.trades"
         class="flex-1 candle-chart-container px-0 h-full align-self-stretch min-w-0 overflow-y-auto"
         :slider-position="sliderPosition"
         :freqai-model="freqaiModel"
+        allow-timeframe-switch
+        :available-timeframes="['5m', '4h', '1d']"
         @refresh-data="refreshOHLCV"
       >
       </CandleChartContainer>

--- a/src/stores/chartConfig.ts
+++ b/src/stores/chartConfig.ts
@@ -3,14 +3,17 @@ export const useChartConfigStore = defineStore(
   () => {
     const strategy = ref<string>('');
     const useLiveData = ref<boolean>(false);
-    const selectedTimeframe = ref<string>('1h');
+    const selectedTimeframe = ref<string>('');
     const timerange = ref<string>('');
+    // For TradingView timeframe switching (visualization only)
+    const selectedTradingTimeframe = ref<string>('');
 
     return {
       strategy,
       useLiveData,
       selectedTimeframe,
       timerange,
+      selectedTradingTimeframe,
     };
   },
   {

--- a/src/views/ChartsView.vue
+++ b/src/views/ChartsView.vue
@@ -40,11 +40,12 @@ onMounted(() => {
 });
 
 function refreshOHLCV(pair: string, columns: string[]) {
-  console.log('Refreshing OHLCV for pair:', pair, finalTimeframe.value, 'with columns:', columns);
-  if (botStore.activeBot.isWebserverMode && finalTimeframe.value) {
+  const tf = chartStore.selectedTimeframe || botStore.activeBot.timeframe;
+  console.log('Refreshing OHLCV for pair:', pair, tf, 'with columns:', columns);
+  if (botStore.activeBot.isWebserverMode && tf) {
     const payload: PairHistoryPayload = {
       pair: pair,
-      timeframe: finalTimeframe.value,
+      timeframe: tf,
       timerange: chartStore.timerange,
       strategy: chartStore.strategy,
       // freqaimodel: freqaiModel.value,
@@ -60,7 +61,7 @@ function refreshOHLCV(pair: string, columns: string[]) {
   } else {
     botStore.activeBot.getPairCandles({
       pair: pair,
-      timeframe: finalTimeframe.value,
+      timeframe: tf,
       columns: columns,
     });
   }
@@ -158,7 +159,10 @@ watch(
         :trades="botStore.activeBot.allTrades"
         :timerange="botStore.activeBot.isWebserverMode ? chartStore.timerange : undefined"
         :strategy="botStore.activeBot.isWebserverMode ? chartStore.strategy : undefined"
+        allow-timeframe-switch
+        :available-timeframes="['5m', '4h', '1d']"
         @refresh-data="refreshOHLCV"
+        @update:timeframe="chartStore.selectedTimeframe = $event"
       >
       </CandleChartContainer>
     </div>

--- a/src/views/TradingView.vue
+++ b/src/views/TradingView.vue
@@ -4,6 +4,7 @@ import type { GridItemData } from '@/types';
 const botStore = useBotStore();
 const layoutStore = useLayoutStore();
 const settingsStore = useSettingsStore();
+const chartStore = useChartConfigStore();
 const currentBreakpoint = ref('');
 
 const breakpointChanged = (newBreakpoint: string) => {
@@ -49,10 +50,10 @@ const responsiveGridLayouts = computed(() => {
   };
 });
 
-function refreshOHLCV(pair: string, columns: string[]) {
+function refreshOHLCV(pair: string, columns: string[], timeframe?: string) {
   botStore.activeBot.getPairCandles({
     pair: pair,
-    timeframe: botStore.activeBot.timeframe,
+    timeframe: timeframe || chartStore.selectedTradingTimeframe || botStore.activeBot.timeframe,
     columns: columns,
   });
 }
@@ -245,11 +246,17 @@ function refreshOHLCV(pair: string, columns: string[]) {
         drag-allow-from=".drag-header"
       >
         <DraggableContainer header="Chart">
+          <div class="flex items-center gap-2 mb-2 px-1">
+            <span class="text-sm text-surface-600 dark:text-surface-400">Timeframe:</span>
+            <TimeframeSelect v-model="chartStore.selectedTradingTimeframe" size="small" />
+          </div>
           <CandleChartContainer
             :available-pairs="botStore.activeBot.whitelist"
             :historic-view="!!false"
-            :timeframe="botStore.activeBot.timeframe"
+            v-model:timeframe="chartStore.selectedTradingTimeframe"
             :trades="botStore.activeBot.allTrades"
+            allow-timeframe-switch
+            :available-timeframes="['5m', '4h', '1d']"
             @refresh-data="refreshOHLCV"
           >
           </CandleChartContainer>


### PR DESCRIPTION
## Summary

Add dynamic data loading from exchange when timeframe is not cached in `get_analyzed_dataframe()`.

## Quick changelog

- Added dynamic data loading in `get_analyzed_dataframe()` when pair/timeframe combination is not found in cache
- Uses `refresh_latest_ohlcv()` to fetch data from exchange in live/dry-run modes
- Added proper error handling and logging for data loading failures

## What's new

This PR improves the `DataProvider.get_analyzed_dataframe()` method by adding fallback logic to dynamically load OHLCV data from the exchange when the requested pair/timeframe combination is not found in the internal cache.

**Key changes:**

- When running in `DRY_RUN` or `LIVE` mode, if the requested pair/timeframe is not cached, the method now attempts to fetch fresh data from the exchange using `refresh_latest_ohlcv()`
- Successfully loaded data is cached and returned immediately
- Added appropriate warning logs when data loading fails or no data is available
- This enhancement allows strategies to request informative pairs with different timeframes without requiring them to be pre-configured in the pairlis