### PR TITLE
chore: disable package-manager cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,7 @@ jobs:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ matrix.node }}
-        cache: 'pnpm'
-
+        package-manager-cache: false
 
     - run: pnpm install
 


### PR DESCRIPTION
<!-- Thank you for sending your pull request. 
Please make sure that common ci checks pass (lint, test:unit, test:e2e, typecheck).

Did you use AI to create your changes?
If so, please state it clearly in the PR description (failing to do so may result in your PR being closed).

Also, please do a self review of the changes made before submitting the PR to make sure only relevant changes are included.

-->

## Summary

Disable package manager cache - it's not considered secure if releases use the same flow.

